### PR TITLE
Add name to bookdown and blogdown examples

### DIFF
--- a/examples/blogdown.yaml
+++ b/examples/blogdown.yaml
@@ -2,6 +2,8 @@ on:
   push:
     branches: master
 
+name: blogdown
+
 jobs:
   build:
     runs-on: macOS-latest

--- a/examples/bookdown.yaml
+++ b/examples/bookdown.yaml
@@ -2,6 +2,8 @@ on:
   push:
     branches: master
 
+name: bookdown
+
 jobs:
   build:
     runs-on: macOS-latest


### PR DESCRIPTION
I spotted these two examples were missing names.