### PR TITLE
pr-fetch action: support private repos

### DIFF
--- a/pr-fetch/lib/main.js
+++ b/pr-fetch/lib/main.js
@@ -33,9 +33,8 @@ function run() {
                 pull_number: issue.number
             });
             const headBranch = pr.head.ref;
-            const headCloneURL = pr.head.repo.clone_url;
-            const headCloneURL2 = headCloneURL.replace("https://", `https://x-access-token:${token}@`);
-            yield exec.exec("git", ["remote", "add", "pr", headCloneURL2]);
+            const headCloneURL = pr.head.repo.clone_url.replace("https://", `https://x-access-token:${token}@`);
+            yield exec.exec("git", ["remote", "add", "pr", headCloneURL]);
             yield exec.exec("git", ["fetch", "pr", headBranch]);
             yield exec.exec("git", ["checkout", "-b", headBranch, `pr/${headBranch}`]);
         }

--- a/pr-fetch/lib/main.js
+++ b/pr-fetch/lib/main.js
@@ -35,7 +35,7 @@ function run() {
             const headBranch = pr.head.ref;
             const headCloneURL = pr.head.repo.clone_url;
             const headCloneURL2 = headCloneURL.replace("https://", `https://x-access-token:${token}@`);
-            yield exec.exec("git", ["remote", "add", "pr", headCloneURL]);
+            yield exec.exec("git", ["remote", "add", "pr", headCloneURL2]);
             yield exec.exec("git", ["fetch", "pr", headBranch]);
             yield exec.exec("git", ["checkout", "-b", headBranch, `pr/${headBranch}`]);
         }

--- a/pr-fetch/src/main.ts
+++ b/pr-fetch/src/main.ts
@@ -29,7 +29,7 @@ async function run() {
       `https://x-access-token:${token}@`
     );
 
-    await exec.exec("git", ["remote", "add", "pr", headCloneURL]);
+    await exec.exec("git", ["remote", "add", "pr", headCloneURL2]);
     await exec.exec("git", ["fetch", "pr", headBranch]);
     await exec.exec("git", ["checkout", "-b", headBranch, `pr/${headBranch}`]);
   } catch (error) {

--- a/pr-fetch/src/main.ts
+++ b/pr-fetch/src/main.ts
@@ -22,14 +22,12 @@ async function run() {
     });
 
     const headBranch: string = pr.head.ref;
-    const headCloneURL: string = pr.head.repo.clone_url;
-
-    const headCloneURL2: string = headCloneURL.replace(
+    const headCloneURL: string = pr.head.repo.clone_url.replace(
       "https://",
       `https://x-access-token:${token}@`
     );
 
-    await exec.exec("git", ["remote", "add", "pr", headCloneURL2]);
+    await exec.exec("git", ["remote", "add", "pr", headCloneURL]);
     await exec.exec("git", ["fetch", "pr", headBranch]);
     await exec.exec("git", ["checkout", "-b", headBranch, `pr/${headBranch}`]);
   } catch (error) {

--- a/pr-push/lib/main.js
+++ b/pr-push/lib/main.js
@@ -33,9 +33,8 @@ function run() {
                 pull_number: issue.number
             });
             const headBranch = pr.head.ref;
-            const headCloneURL = pr.head.repo.clone_url;
-            const headCloneURL2 = headCloneURL.replace("https://", `https://x-access-token:${token}@`);
-            yield exec.exec("git", ["push", headCloneURL2, `HEAD:${headBranch}`]);
+            const headCloneURL = pr.head.repo.clone_url.replace("https://", `https://x-access-token:${token}@`);
+            yield exec.exec("git", ["push", headCloneURL, `HEAD:${headBranch}`]);
         }
         catch (error) {
             core.setFailed(error.message);

--- a/pr-push/src/main.ts
+++ b/pr-push/src/main.ts
@@ -22,14 +22,12 @@ async function run() {
     });
 
     const headBranch: string = pr.head.ref;
-    const headCloneURL: string = pr.head.repo.clone_url;
-
-    const headCloneURL2: string = headCloneURL.replace(
+    const headCloneURL: string = pr.head.repo.clone_url.replace(
       "https://",
       `https://x-access-token:${token}@`
     );
 
-    await exec.exec("git", ["push", headCloneURL2, `HEAD:${headBranch}`]);
+    await exec.exec("git", ["push", headCloneURL, `HEAD:${headBranch}`]);
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
The pr-fetch action currently fails authentication for private repos.

This PR makes it use the authenticated URL, just like the pr-push action already does.