### PR TITLE
`\document`, `\style` -> `/document`, `/style`

### DIFF
--- a/examples/README.Rmd
+++ b/examples/README.Rmd
@@ -54,9 +54,9 @@ print_yaml("check-full.yaml")
 ## Commands workflow
 
 This workflow enables the use of 2 R specific commands in pull request issue
-comments. `\document` will use [roxygen2](https://roxygen2.r-lib.org/) to
+comments. `/document` will use [roxygen2](https://roxygen2.r-lib.org/) to
 rebuild the documentation for the package and commit the result to the pull
-request. `\style` will use [styler](https://styler.r-lib.org/) to restyle your
+request. `/style` will use [styler](https://styler.r-lib.org/) to restyle your
 package.
 
 ## When it can they be used?


### PR DESCRIPTION
The action seems to work with `/` not `\`.

e.g. : https://github.com/r-lib/actions/blob/f7db652d87e2871912df64d88fa838e509282857/examples/pr-commands.yaml#L7

A similar fix seems necessary at https://github.com/r-lib/usethis/blob/7d824f1f21b38594acc30f55a2c16a56804a552b/R/github-action.R#L86

BTW, I also see [sectrets.GITHUB_TOKEN](https://github.com/r-lib/actions/blob/f7db652d87e2871912df64d88fa838e509282857/examples/pr-commands.yaml#L14). I expected `secret.GITHUB_PAT` for consistency with `usethis::browse_github_token()` and `usethis::browse_github_pat()` (both create `GITHUB_PAT` not `GITHUB_TOKEN`).

