### PR TITLE
Install pkg-config on MacOS

### DIFF
--- a/setup-r/lib/installer.js
+++ b/setup-r/lib/installer.js
@@ -84,7 +84,7 @@ function acquireR(version, rtoolsVersion) {
             else if (IS_MAC) {
                 yield Promise.all([
                     acquireFortranMacOS(),
-                    acquireQpdfMacOS(),
+                    acquireUtilsMacOS(),
                     acquireRMacOS(version)
                 ]);
                 if (core.getInput("remove-openmp-macos")) {
@@ -126,11 +126,11 @@ function acquireFortranMacOS() {
         }
     });
 }
-function acquireQpdfMacOS() {
+function acquireUtilsMacOS() {
     return __awaiter(this, void 0, void 0, function* () {
         // qpdf is needed by `--as-cran`
         try {
-            yield exec.exec("brew", ["install", "qpdf"]);
+            yield exec.exec("brew", ["install", "qpdf", "pkgconfig"]);
         }
         catch (error) {
             core.debug(error);

--- a/setup-r/src/installer.ts
+++ b/setup-r/src/installer.ts
@@ -64,7 +64,7 @@ async function acquireR(version: string, rtoolsVersion: string) {
     } else if (IS_MAC) {
       await Promise.all([
         acquireFortranMacOS(),
-        acquireQpdfMacOS(),
+        acquireUtilsMacOS(),
         acquireRMacOS(version)
       ]);
       if (core.getInput("remove-openmp-macos")) {
@@ -104,10 +104,10 @@ async function acquireFortranMacOS() {
   }
 }
 
-async function acquireQpdfMacOS() {
+async function acquireUtilsMacOS() {
   // qpdf is needed by `--as-cran`
   try {
-    await exec.exec("brew", ["install", "qpdf"]);
+    await exec.exec("brew", ["install", "qpdf", "pkgconfig"]);
   } catch (error) {
     core.debug(error);
 


### PR DESCRIPTION
Packages which use system libraries need to call `pkg-config` in their configure scripts. When this is missing, it leads to confusing errors when installing a package or dependency package from source.

The CRAN mac server requires that packages use `pkg-config` as well linking against system libs.



