### PR TITLE
Use rtools40 for R >= 4.0

### DIFF
--- a/setup-r/action.yml
+++ b/setup-r/action.yml
@@ -6,8 +6,8 @@ inputs:
     description: 'Version range or exact version of an R version to use.'
     default: '3.x'
   rtools-version:
-    description: 'Exact version of Rtools to use.'
-    default: '35'
+    description: 'Exact version of Rtools to use. Default uses latest suitable
+    rtools for the given version of R.'
   Ncpus:
     description: 'Value to set the R option `Ncpus` to.'
     default: '1'

--- a/setup-r/lib/installer.js
+++ b/setup-r/lib/installer.js
@@ -290,8 +290,10 @@ function acquireRWindows(version) {
 }
 function acquireRtools(version) {
     return __awaiter(this, void 0, void 0, function* () {
-        let fileName = util.format("Rtools%s.exe", version);
+        const rtools4 = version.charAt(0) == '4';
+        let fileName = util.format(rtools4 ? "rtools%s-x86_64.exe" : "Rtools%s.exe", version);
         let downloadUrl = util.format("http://cloud.r-project.org/bin/windows/Rtools/%s", fileName);
+        console.log(`Downloading ${downloadUrl}...`);
         let downloadPath = null;
         try {
             downloadPath = yield tc.downloadTool(downloadUrl);
@@ -311,8 +313,14 @@ function acquireRtools(version) {
             core.debug(error);
             throw `Failed to install Rtools: ${error}`;
         }
-        core.addPath(`C:\\Rtools\\bin`);
-        core.addPath(`C:\\Rtools\\mingw_64\\bin`);
+        if (rtools4) {
+            core.addPath(`C:\\rtools40\\mingw64\\bin`);
+            core.addPath(`C:\\rtools40\\usr\\bin`);
+        }
+        else {
+            core.addPath(`C:\\Rtools\\bin`);
+            core.addPath(`C:\\Rtools\\mingw_64\\bin`);
+        }
     });
 }
 function acquireQpdfWindows() {

--- a/setup-r/lib/setup-r.js
+++ b/setup-r/lib/setup-r.js
@@ -24,8 +24,7 @@ function run() {
             core.debug(`started action`);
             let version = core.getInput("r-version");
             core.debug(`got version ${version}`);
-            let rtoolsVersion = core.getInput("rtools-version");
-            core.debug(`got rtools-version ${rtoolsVersion}`);
+            let rtoolsVersion = core.getInput("rtools-version") || (version.charAt(0) == '3' ? '35' : '40');
             yield installer_1.getR(version, rtoolsVersion);
             const matchersPath = path.join(__dirname, "..", ".github");
             console.log(`##[add-matcher]${path.join(matchersPath, "rcmdcheck.json")}`);

--- a/setup-r/src/installer.ts
+++ b/setup-r/src/installer.ts
@@ -275,11 +275,13 @@ async function acquireRWindows(version: string): Promise<string> {
 }
 
 async function acquireRtools(version: string) {
-  let fileName: string = util.format("Rtools%s.exe", version);
+  const rtools4 = version.charAt(0) == '4';
+  let fileName: string = util.format(rtools4 ? "rtools%s-x86_64.exe" : "Rtools%s.exe", version);
   let downloadUrl: string = util.format(
     "http://cloud.r-project.org/bin/windows/Rtools/%s",
     fileName
   );
+  console.log(`Downloading ${downloadUrl}...`);
   let downloadPath: string | null = null;
   try {
     downloadPath = await tc.downloadTool(downloadUrl);
@@ -300,9 +302,13 @@ async function acquireRtools(version: string) {
 
     throw `Failed to install Rtools: ${error}`;
   }
-
-  core.addPath(`C:\\Rtools\\bin`);
-  core.addPath(`C:\\Rtools\\mingw_64\\bin`);
+  if(rtools4){
+    core.addPath(`C:\\rtools40\\usr\\bin`);
+    core.addPath(`C:\\rtools40\\mingw64\\bin`);
+  } else {
+    core.addPath(`C:\\Rtools\\bin`);
+    core.addPath(`C:\\Rtools\\mingw_64\\bin`);
+  }
 }
 
 async function acquireQpdfWindows() {

--- a/setup-r/src/setup-r.ts
+++ b/setup-r/src/setup-r.ts
@@ -7,8 +7,7 @@ async function run() {
     core.debug(`started action`);
     let version = core.getInput("r-version");
     core.debug(`got version ${version}`);
-    let rtoolsVersion = core.getInput("rtools-version");
-    core.debug(`got rtools-version ${rtoolsVersion}`);
+    let rtoolsVersion = core.getInput("rtools-version") || (version.charAt(0) == '3' ? '35' : '40');
 
     await getR(version, rtoolsVersion);
 


### PR DESCRIPTION
Match the default CRAN toolchain, which now uses rtools40 for R 4.0 and R-devel.

The logic is that if `r-version` starts with `3` (for example 3.6 or 3.x) then the default is rtools35. Otherwise (for example `4.0` or `devel`) we need to install rtools40. 

We can tweak this more later, but for now this will suffice to start testing with R-devel (and soon R-4.0).