### PR TITLE
Allow passing arbitrary command-line args to pr-push (closes #88)

### DIFF
--- a/pr-push/action.yml
+++ b/pr-push/action.yml
@@ -4,6 +4,8 @@ author: 'Jim Hester'
 inputs:
   repo-token:
     description: 'Token for the repo. Can be passed in using {{ secrets.GITHUB_TOKEN }}'
+  args:
+    description: 'String of additional command line args to `git push`'
 runs:
   using: 'node12'
   main: 'lib/main.js'

--- a/pr-push/lib/main.js
+++ b/pr-push/lib/main.js
@@ -23,6 +23,7 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const token = core.getInput("repo-token", { required: true });
+            const cli_args = core.getInput("args");
             const client = new github.GitHub(token);
             const context = github.context;
             const issue = context.issue;
@@ -34,7 +35,7 @@ function run() {
             });
             const headBranch = pr.head.ref;
             const headCloneURL = pr.head.repo.clone_url.replace("https://", `https://x-access-token:${token}@`);
-            yield exec.exec("git", ["push", headCloneURL, `HEAD:${headBranch}`]);
+            yield exec.exec("git", ["push", headCloneURL, cli_args, `HEAD:${headBranch}`]);
         }
         catch (error) {
             core.setFailed(error.message);

--- a/pr-push/src/main.ts
+++ b/pr-push/src/main.ts
@@ -5,6 +5,7 @@ import * as exec from "@actions/exec";
 async function run() {
   try {
     const token: string = core.getInput("repo-token", { required: true });
+    const cli_args: string = core.getInput("args");
 
     const client: github.GitHub = new github.GitHub(token);
 
@@ -27,7 +28,7 @@ async function run() {
       `https://x-access-token:${token}@`
     );
 
-    await exec.exec("git", ["push", headCloneURL, `HEAD:${headBranch}`]);
+    await exec.exec("git", ["push", headCloneURL, cli_args, `HEAD:${headBranch}`]);
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
To see this in action, I'm working on an issue_comment workflow to [rebase a PR](https://github.com/apache/arrow/compare/master...nealrichardson:rebase). Using `r-lib/actions/pr-push@master`, [the workflow failed](https://github.com/nealrichardson/arrow/runs/613688351?check_suite_focus=true#step:5:1)  because rebase needs force push, and then here's a [successful run](https://github.com/nealrichardson/arrow/runs/613698512?check_suite_focus=true#step:5:6) using this branch and passing `args: "--force"`.