### PR TITLE
Unbreak pr-push without cli_args

### DIFF
--- a/pr-push/action.yml
+++ b/pr-push/action.yml
@@ -6,6 +6,7 @@ inputs:
     description: 'Token for the repo. Can be passed in using {{ secrets.GITHUB_TOKEN }}'
   args:
     description: 'String of additional command line args to `git push`'
+    default: '-q'
 runs:
   using: 'node12'
   main: 'lib/main.js'


### PR DESCRIPTION
#90 added the ability to specify extra command-line args to `git push`. It apparently had the side effect of making `pr-push` fail if you *didn't* specify cli_args, like [this](https://github.com/nealrichardson/arrow/runs/624090772?check_suite_focus=true#step:11:12). I thought I had tested that nothing broke when I added it, and when I try to run the identical `git` commands locally, they aren't troubled by the extra whitespace, but apparently that's not good enough. 🙈 sorry! 

A quick fix is to add an innocuous default value for `cli_args` so that it isn't empty. [I confirmed that this fixes](https://github.com/nealrichardson/arrow/runs/624146379?check_suite_focus=true#step:11:12) the failed run from above.