### PR TITLE
Fix a missed filename change

### DIFF
--- a/examples/render-readme.yaml
+++ b/examples/render-readme.yaml
@@ -19,5 +19,5 @@ jobs:
         run: Rscript -e 'rmarkdown::render("README.Rmd")'
       - name: Commit results
         run: |
-          git commit examples/README.md -m 'Re-build README.Rmd' || echo "No changes to commit"
+          git commit README.md -m 'Re-build README.Rmd' || echo "No changes to commit"
           git push origin || echo "No changes to commit"


### PR DESCRIPTION
The `git commit` step was still referencing `examples/README.md`. This PR changes the file to be committed to `README.md` to match the other path/file names.