### PR TITLE
Add the link to a Bioconductor-friendly GHA workflow

### DIFF
--- a/examples/README.Rmd
+++ b/examples/README.Rmd
@@ -162,6 +162,32 @@ the report as a build artifact.
 print_yaml("docker.yaml")
 ```
 
+## Bioconductor-friendly workflow
+
+[Bioconductor](http://bioconductor.org/) is a repository for tools for
+the analysis and comprehension of high-throughput genomic data that
+hosts close to 2,000 R packages. It follows a six month release cycle
+while R has a yearly release cycle. `biocthis` contains a
+user-contributed workflow that is Bioconductor-friendly described in
+detail at[the `biocthis` introductory vignette](https://lcolladotor.github.io/biocthis/articles/biocthis.html#use-bioc-github-action-).
+You can add this workflow using the following R code:
+
+```{r biocthis_gha, eval = FALSE}
+## If needed
+remotes::install_github("lcolladotor/biocthis")
+
+## Create a GitHub Actions (GHA) workflow that is Bioconductor-friendly
+biocthis::use_bioc_github_action()
+
+## You can also use this GHA workflow without installing biocthis
+usethis::use_github_action(
+    "check-bioc",
+    "https://bit.ly/biocthis_gha",
+    "check-bioc.yml"
+)
+```
+
+
 ## Forcing binaries
 
 Code repositories such as [CRAN](http://cran.r-project.org) or [RStudio](http://rstudio.com)'s RSPM provide R packages in binary (= pre-compiled) form for some platforms, but these binaries can sometimes be missing our lag behind the package sources published on the repository.

--- a/examples/README.md
+++ b/examples/README.md
@@ -709,6 +709,31 @@ jobs:
           path: report.html
 ```
 
+## Bioconductor-friendly workflow
+
+[Bioconductor](http://bioconductor.org/) is a repository for tools for
+the analysis and comprehension of high-throughput genomic data that
+hosts close to 2,000 R packages. It follows a six month release cycle
+while R has a yearly release cycle. `biocthis` contains a
+user-contributed workflow that is Bioconductor-friendly described in
+detail at[the `biocthis` introductory vignette](https://lcolladotor.github.io/biocthis/articles/biocthis.html#use-bioc-github-action-).
+You can add this workflow using the following R code:
+
+``` r
+## If needed
+remotes::install_github("lcolladotor/biocthis")
+
+## Create a GitHub Actions (GHA) workflow that is Bioconductor-friendly
+biocthis::use_bioc_github_action()
+
+## You can also use this GHA workflow without installing biocthis
+usethis::use_github_action(
+    "check-bioc",
+    "https://bit.ly/biocthis_gha",
+    "check-bioc.yml"
+)
+```
+
 ## Forcing binaries
 
 Code repositories such as [CRAN](http://cran.r-project.org) or


### PR DESCRIPTION
Under the example READMEs, this commit adds a short paragraph
describing the Bioconductor-friendly GitHub Actions workflow
from `biocthis`. The README.md file was manually edited while
trying to keep the line length consistent with how it currently
is rendered. Rendering manually following the steps at
https://github.com/r-lib/actions/blob/master/.github/workflows/render-readme.yaml
resulted in long lines instead of the nice broken up lines.

This commit and PR closes https://github.com/r-lib/actions/issues/84 as discussed previously.