### PR TITLE
Rstudio compatibility

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,5 @@
 ^examples$
 ^LICENSE$
 ^.github$
+^actions\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.Rproj.user

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,4 @@
-Package: testpackage
+Package: actions
 Title: A Simple Test Description File to Test Packages
 Version: 1.0.0
 Authors@R: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,4 @@
-Package: actions
+Package: testpackage
 Title: A Simple Test Description File to Test Packages
 Version: 1.0.0
 Authors@R: 

--- a/actions.Rproj
+++ b/actions.Rproj
@@ -1,0 +1,22 @@
+Version: 1.0
+
+RestoreWorkspace: No
+SaveWorkspace: No
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+LineEndingConversion: Posix
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
The first commit here is the one I'd really like. Without it, `usethis::create_from_github(rstudio = TRUE)` creates a Project (`.Rproj`, really) called "testpackage", even though the directory and projects really "actions".

The second commit adds the usual boilerplate stuff for an RStudio Project. But if you object to that, we can revert.