### PR TITLE
Don't install remotes a second time

### DIFF
--- a/examples/pkgdown.yaml
+++ b/examples/pkgdown.yaml
@@ -32,7 +32,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          install.packages("remotes")
           remotes::install_deps(dependencies = TRUE)
           install.packages("pkgdown")
         shell: Rscript {0}


### PR DESCRIPTION
I pulled the recent changes in a package to get the git user config. My workflow has lots of customization, so I had to stage/discard in a very detailed way and noticed that the pkgdown workflow installs remotes twice.

Is that intentional? If not, I removed the second instance.