### PR TITLE
Do not override NOT_CRAN if preset

### DIFF
--- a/setup-r/lib/installer.js
+++ b/setup-r/lib/installer.js
@@ -422,7 +422,8 @@ function getDownloadUrlWindows(version) {
 function setREnvironmentVariables() {
     core.exportVariable("R_LIBS_USER", path.join(tempDirectory, "Library"));
     core.exportVariable("TZ", "UTC");
-    core.exportVariable("NOT_CRAN", "true");
+    if (!process.env["NOT_CRAN"])
+        core.exportVariable("NOT_CRAN", "true");
 }
 function determineVersion(version) {
     return __awaiter(this, void 0, void 0, function* () {

--- a/setup-r/src/installer.ts
+++ b/setup-r/src/installer.ts
@@ -448,7 +448,8 @@ async function getDownloadUrlWindows(version: string): Promise<string> {
 function setREnvironmentVariables() {
   core.exportVariable("R_LIBS_USER", path.join(tempDirectory, "Library"));
   core.exportVariable("TZ", "UTC");
-  core.exportVariable("NOT_CRAN", "true");
+  if(!process.env["NOT_CRAN"])
+    core.exportVariable("NOT_CRAN", "true");
 }
 
 async function determineVersion(version: string): Promise<string> {


### PR DESCRIPTION
I would like to have a test job that uses `NOT_CRAN = FALSE` however currently this variable is set to `true` unconditionally. The following changes it such that `NOT_CRAN` is only set when not pre-set.