### PR TITLE
Add a second bookdown example (no renv, gh-pages)

### DIFF
--- a/examples/README.Rmd
+++ b/examples/README.Rmd
@@ -142,7 +142,7 @@ print_yaml("bookdown.yaml")
 ## Build bookdown site, alternative
 
 This example builds a [bookdown] site for a repository and pushes the built site
-to [GitHub Pages]. It does *not* use renv.
+to [GitHub Pages]. It does *not* use renv. This workflow will create the orphan `gh-pages` branch, but it does *not* turn on GitHub Pages. You must do that yourself in the repository's settings. If your site isn't working, the first troubleshooting step should be to turn GitHub Pages off, then on again.
 
 ```{r echo = FALSE, results = "asis"}
 print_yaml("bookdown-gh-pages.yaml")

--- a/examples/README.Rmd
+++ b/examples/README.Rmd
@@ -16,6 +16,7 @@ print_yaml <- function(filename) {
 - [lint](#lint-workflow) - Run `lintr::lint_package()` on an R package.
 - [Build pkgdown site](#build-pkgdown-site) - Build a [pkgdown] site for an R package and deploy it to [GitHub Pages].
 - [Build bookdown site](#build-bookdown-site) - Build a [bookdown] site and deploy it to [netlify].
+- [Build bookdown site, alternative](#build-bookdown-site-alternative) - Build a [bookdown] site and deploy it to [GitHub Pages].
 - [Build blogdown site](#build-blogdown-site) - Build a [blogdown] site and deploy it to [netlify].
 - [Managing secrets](#managing-secrets) - How to generate auth tokens and make them available to actions.
 
@@ -136,6 +137,15 @@ You will need to run `renv::snapshot()` locally and commit the `renv.lock` file 
 
 ```{r echo = FALSE, results = "asis"}
 print_yaml("bookdown.yaml")
+```
+
+## Build bookdown site, alternative
+
+This example builds a [bookdown] site for a repository and pushes the built site
+to [GitHub Pages]. It does *not* use renv.
+
+```{r echo = FALSE, results = "asis"}
+print_yaml("bookdown-gh-pages.yaml")
 ```
 
 ## Build blogdown site

--- a/examples/README.md
+++ b/examples/README.md
@@ -645,7 +645,11 @@ jobs:
 
 This example builds a [bookdown](https://bookdown.org) site for a
 repository and pushes the built site to [GitHub
-Pages](https://pages.github.com/). It does *not* use renv.
+Pages](https://pages.github.com/). It does *not* use renv. This workflow
+will create the orphan `gh-pages` branch, but it does *not* turn on
+GitHub Pages. You must do that yourself in the repository’s settings. If
+your site isn’t working, the first troubleshooting step should be to
+turn GitHub Pages off, then on again.
 
 ``` yaml
 on:

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,9 @@
   - [Build bookdown site](#build-bookdown-site) - Build a
     [bookdown](https://bookdown.org) site and deploy it to
     [netlify](https://www.netlify.com/).
+  - [Build bookdown site, alternative](#build-bookdown-site-alternative)
+    - Build a [bookdown](https://bookdown.org) site and deploy it to
+    [GitHub Pages](https://pages.github.com/).
   - [Build blogdown site](#build-blogdown-site) - Build a
     [blogdown](https://bookdown.org/yihui/blogdown/) site and deploy it
     to [netlify](https://www.netlify.com/).
@@ -636,6 +639,107 @@ jobs:
         run: |
           npm install netlify-cli -g
           netlify deploy --prod --dir _book
+```
+
+## Build bookdown site, alternative
+
+This example builds a [bookdown](https://bookdown.org) site for a
+repository and pushes the built site to [GitHub
+Pages](https://pages.github.com/). It does *not* use renv.
+
+``` yaml
+on:
+  push:
+    branches: master
+
+name: bookdown
+
+jobs:
+  bookdown:
+    runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@master
+
+      - name: Install pandoc and pandoc citeproc
+        run: |
+          brew install pandoc
+          brew install pandoc-citeproc
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Cache bookdown results
+        uses: actions/cache@v1
+        with:
+          path: _bookdown_files
+          key: bookdown-${{ hashFiles('**/*Rmd') }}
+          restore-keys: bookdown-
+
+      - name: Install dependencies
+        run: |
+          remotes::install_deps(dependencies = TRUE)
+          install.packages("bookdown")
+        shell: Rscript {0}
+
+      - name: Configure Git
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Ensure origin/gh-pages exists
+        run: |
+          if ! git ls-remote --exit-code --heads origin gh-pages; then
+            git checkout --orphan gh-pages
+            git reset --hard
+            git commit --allow-empty -m "Initializing gh-pages branch"
+            git push origin gh-pages
+            git checkout master
+          fi
+
+      - name: Create a temporary directory to render in
+        run: |
+          DIR=$(mktemp -d)
+          echo "::set-env name=BOOKDOWN_OUTPUT_PATH::$DIR"
+
+      - name: Git prep
+        run: |
+          git branch -vv
+          git fetch --no-tags --depth=1 origin +refs/heads/gh-pages:refs/remotes/origin/gh-pages
+          git worktree add --track -B gh-pages $BOOKDOWN_OUTPUT_PATH origin/gh-pages
+          # git worktree add --checkout ${temporaryDeploymentDirectory} origin/${action.branch}
+
+      - name: Build site
+        run: |
+          Rscript -e 'bookdown::render_book("index.Rmd", quiet = TRUE, output_dir = Sys.getenv("BOOKDOWN_OUTPUT_PATH"))'
+
+      - name: Deploy to gh-pages
+        working-directory: ${{env.BOOKDOWN_OUTPUT_PATH}}
+        run: |
+          touch .nojekyll
+          git add --all
+          git commit --allow-empty -m "GHA render of ${GITHUB_SHA::8}"
+          git push --force origin gh-pages
+
+      - name: Clean up
+        run: |
+          git worktree remove $BOOKDOWN_OUTPUT_PATH
 ```
 
 ## Build blogdown site

--- a/examples/README.md
+++ b/examples/README.md
@@ -723,7 +723,6 @@ jobs:
           git branch -vv
           git fetch --no-tags --depth=1 origin +refs/heads/gh-pages:refs/remotes/origin/gh-pages
           git worktree add --track -B gh-pages $BOOKDOWN_OUTPUT_PATH origin/gh-pages
-          # git worktree add --checkout ${temporaryDeploymentDirectory} origin/${action.branch}
 
       - name: Build site
         run: |

--- a/examples/bookdown-gh-pages.yaml
+++ b/examples/bookdown-gh-pages.yaml
@@ -1,0 +1,92 @@
+on:
+  push:
+    branches: master
+
+name: bookdown
+
+jobs:
+  bookdown:
+    runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@master
+
+      - name: Install pandoc and pandoc citeproc
+        run: |
+          brew install pandoc
+          brew install pandoc-citeproc
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Cache bookdown results
+        uses: actions/cache@v1
+        with:
+          path: _bookdown_files
+          key: bookdown-${{ hashFiles('**/*Rmd') }}
+          restore-keys: bookdown-
+
+      - name: Install dependencies
+        run: |
+          remotes::install_deps(dependencies = TRUE)
+          install.packages("bookdown")
+        shell: Rscript {0}
+
+      - name: Configure Git
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Ensure origin/gh-pages exists
+        run: |
+          if ! git ls-remote --exit-code --heads origin gh-pages; then
+            git checkout --orphan gh-pages
+            git reset --hard
+            git commit --allow-empty -m "Initializing gh-pages branch"
+            git push origin gh-pages
+            git checkout master
+          fi
+
+      - name: Create a temporary directory to render in
+        run: |
+          DIR=$(mktemp -d)
+          echo "::set-env name=BOOKDOWN_OUTPUT_PATH::$DIR"
+
+      - name: Git prep
+        run: |
+          git branch -vv
+          git fetch --no-tags --depth=1 origin +refs/heads/gh-pages:refs/remotes/origin/gh-pages
+          git worktree add --track -B gh-pages $BOOKDOWN_OUTPUT_PATH origin/gh-pages
+          # git worktree add --checkout ${temporaryDeploymentDirectory} origin/${action.branch}
+
+      - name: Build site
+        run: |
+          Rscript -e 'bookdown::render_book("index.Rmd", quiet = TRUE, output_dir = Sys.getenv("BOOKDOWN_OUTPUT_PATH"))'
+
+      - name: Deploy to gh-pages
+        working-directory: ${{env.BOOKDOWN_OUTPUT_PATH}}
+        run: |
+          touch .nojekyll
+          git add --all
+          git commit --allow-empty -m "GHA render of ${GITHUB_SHA::8}"
+          git push --force origin gh-pages
+
+      - name: Clean up
+        run: |
+          git worktree remove $BOOKDOWN_OUTPUT_PATH

--- a/examples/bookdown-gh-pages.yaml
+++ b/examples/bookdown-gh-pages.yaml
@@ -73,7 +73,6 @@ jobs:
           git branch -vv
           git fetch --no-tags --depth=1 origin +refs/heads/gh-pages:refs/remotes/origin/gh-pages
           git worktree add --track -B gh-pages $BOOKDOWN_OUTPUT_PATH origin/gh-pages
-          # git worktree add --checkout ${temporaryDeploymentDirectory} origin/${action.branch}
 
       - name: Build site
         run: |


### PR DESCRIPTION
I have had success with this in a situation where simplicity was paramount, i.e. neither renv nor netlify seemed like desirable additions. And, in that actual project, we had switched the default branch from `master` to `main`, which means you *must* deploy to the `gh-pages` branch (as opposed to serving from `docs/`.