### PR TITLE
add where to find the value of the NETLIFY_SITE_ID variable

### DIFF
--- a/examples/README.Rmd
+++ b/examples/README.Rmd
@@ -132,7 +132,7 @@ print_yaml("pkgdown.yaml")
 This example builds a [bookdown] site for a repository and then deploys the site via [netlify].
 It uses [renv] to ensure the package versions remain consistent across builds.
 You will need to run `renv::snapshot()` locally and commit the `renv.lock` file before using this workflow, see [Using renv with Continous Integeration](https://rstudio.github.io/renv/articles/ci.html) for additional information.
-**Note** you need to add a `NETLIFY_AUTH_TOKEN` secret to your repository for the netlify deploy (see [Managing secrets](#managing-secrets) section for details).
+**Note** you need to add a `NETLIFY_AUTH_TOKEN` and a `NETLIFY_SITE_ID` secret to your repository for the netlify deploy (see [Managing secrets](#managing-secrets) section for details).
 
 ```{r echo = FALSE, results = "asis"}
 print_yaml("bookdown.yaml")
@@ -143,7 +143,7 @@ print_yaml("bookdown.yaml")
 This example builds a [blogdown] site for a repository and then deploys the book via [netlify].
 It uses [renv] to ensure the package versions remain consistent across builds.
 You will need to run `renv::snapshot()` locally and commit the `renv.lock` file before using this workflow, see [Using renv with Continous Integeration](https://rstudio.github.io/renv/articles/ci.html) for additional information.
-**Note** you need to add a `NETLIFY_AUTH_TOKEN` secret to your repository for the netlify deploy (see [Managing secrets](#managing-secrets) section for details).
+**Note** you need to add a `NETLIFY_AUTH_TOKEN` a `NETLIFY_SITE_ID` secret to your repository for the netlify deploy (see [Managing secrets](#managing-secrets) section for details).
 
 ```{r echo = FALSE, results = "asis"}
 print_yaml("blogdown.yaml")
@@ -217,7 +217,7 @@ You can learn more about packages in source and binary form [here](https://r-pkg
 
 In some cases, your action may need to access an external resource to deploy a result of your action. 
 For example, the [bookdown]() and [blogdown]() actions require access to your Netlify account. 
-This access is managed using a personal access token, commonly called a PAT.
+This access is managed using a Personal Access Token, commonly called a PAT.
 
 Netlify has a [process for creating a PAT using their UI](https://docs.netlify.com/cli/get-started/#obtain-a-token-in-the-netlify-ui), which we follow here.
 
@@ -240,6 +240,8 @@ Netlify has a [process for creating a PAT using their UI](https://docs.netlify.c
    - Click "Add Secret".
    
 5. At this point (certainly at some point), you may wish to close your **tokens** page to remove the visibility of your token.
+
+The `NETLIFY_SITE_ID` is not quite as personal as the PAT and is visible from your Netlify profile. This is the value of the **API ID** variable that is listed on your site dashboard under Settings > General > Site details > Site information.
 
 [GitHub Pages]: https://pages.github.com/
 [renv]: https://rstudio.github.io/renv/


### PR DESCRIPTION
the bookdown and blogdown workflows refer to the `NETLIFY_SITE_ID` variable but how to set its value isn't explained in the README. 