### PR TITLE
force binary installation of dependencies in pkgdown workflow

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          remotes::install_deps(dependencies = TRUE)
+          remotes::install_deps(dependencies = TRUE, type = "binary")
           install.packages("pkgdown")
         shell: Rscript {0}
 


### PR DESCRIPTION
This PR addresses issues arising when the dependencies of pkgdown have a source version available that is more recent than the binary version and the system requirements are not available for compilation