### PR TITLE
examples README: add missing sections to toc 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .Rproj.user
+.Rhistory

--- a/examples/README.Rmd
+++ b/examples/README.Rmd
@@ -2,6 +2,8 @@
 output: github_document
 ---
 
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
 ```{r setup, include = FALSE}
 print_yaml <- function(filename) {
   cat("```yaml", readLines(filename), "```", sep = "\n")
@@ -11,13 +13,16 @@ print_yaml <- function(filename) {
 - [Quickstart CI](#quickstart-ci-workflow) - A simple CI workflow to check with the release version of R.
 - [Standard CI](#standard-ci-workflow) - A standard CI workflow to check with the release version of R on the three major OSs.
 - [Tidyverse CI](#tidyverse-ci-workflow) - A more complex CI workflow
-- [Pull Request Commands](#commands-workflow) - Adds `/document` and `/style` commands for pull requests.
-- [Render README](#render-readme) - Render README.Rmd when it changes and commit the result
 - [Test coverage](#test-coverage-workflow) - Run `covr::codecov()` on an R package.
-- [lint](#lint-workflow) - Run `lintr::lint_package()` on an R package.
+- [Lint package](#lint-workflow) - Run `lintr::lint_package()` on an R package.
+- [Pull request commands](#commands-workflow) - Adds `/document` and `/style` commands for pull requests.
+- [Render README](#render-readme) - Render README.Rmd when it changes and commit the result
 - [Build pkgdown site](#build-pkgdown-site) - Build a [pkgdown] site for an R package and deploy it to [GitHub Pages].
 - [Build bookdown site](#build-bookdown-site) - Build a [bookdown] site and deploy it to [netlify].
 - [Build blogdown site](#build-blogdown-site) - Build a [blogdown] site and deploy it to [netlify].
+- [Docker](#docker-based-workflow) - For custom workflows based on docker containers.
+- [Bioconductor](#bioconductor-friendly-workflow) - A CI workflow for packages to be released on Bioconductor.
+- [Forcing binaries](#forcing-binaries) - An environment variable to always use binary packages. 
 - [Managing secrets](#managing-secrets) - How to generate auth tokens and make them available to actions.
 
 ## Quickstart CI workflow
@@ -100,7 +105,7 @@ rebuild the documentation for the package and commit the result to the pull
 request. `/style` will use [styler](https://styler.r-lib.org/) to restyle your
 package.
 
-## When it can they be used?
+### When should you use it?
 
 1. You get frequent pull requests, often with documentation only fixes.
 2. You regularly style your code with styler, and require all additions be

--- a/examples/README.Rmd
+++ b/examples/README.Rmd
@@ -9,6 +9,7 @@ print_yaml <- function(filename) {
 ```
 
 - [Quickstart CI](#quickstart-ci-workflow) - A simple CI workflow to check with the release version of R.
+- [Standard CI](#standard-ci-workflow) - A standard CI workflow to check with the release version of R on the three major OSs.
 - [Tidyverse CI](#tidyverse-ci-workflow) - A more complex CI workflow
 - [Pull Request Commands](#commands-workflow) - Adds `/document` and `/style` commands for pull requests.
 - [Render README](#render-readme) - Render README.Rmd when it changes and commit the result

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,8 @@
 
   - [Quickstart CI](#quickstart-ci-workflow) - A simple CI workflow to
     check with the release version of R.
+  - [Standard CI](#standard-ci-workflow) - A standard CI workflow to
+    check with the release version of R on the three major OSs.
   - [Tidyverse CI](#tidyverse-ci-workflow) - A more complex CI workflow
   - [Pull Request Commands](#commands-workflow) - Adds `/document` and
     `/style` commands for pull requests.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,17 +1,19 @@
 
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
   - [Quickstart CI](#quickstart-ci-workflow) - A simple CI workflow to
     check with the release version of R.
   - [Standard CI](#standard-ci-workflow) - A standard CI workflow to
     check with the release version of R on the three major OSs.
   - [Tidyverse CI](#tidyverse-ci-workflow) - A more complex CI workflow
-  - [Pull Request Commands](#commands-workflow) - Adds `/document` and
+  - [Test coverage](#test-coverage-workflow) - Run `covr::codecov()` on
+    an R package.
+  - [Lint package](#lint-workflow) - Run `lintr::lint_package()` on an R
+    package.
+  - [Pull request commands](#commands-workflow) - Adds `/document` and
     `/style` commands for pull requests.
   - [Render README](#render-readme) - Render README.Rmd when it changes
     and commit the result
-  - [Test coverage](#test-coverage-workflow) - Run `covr::codecov()` on
-    an R package.
-  - [lint](#lint-workflow) - Run `lintr::lint_package()` on an R
-    package.
   - [Build pkgdown site](#build-pkgdown-site) - Build a
     [pkgdown](https://pkgdown.r-lib.org/) site for an R package and
     deploy it to [GitHub Pages](https://pages.github.com/).
@@ -21,6 +23,12 @@
   - [Build blogdown site](#build-blogdown-site) - Build a
     [blogdown](https://bookdown.org/yihui/blogdown/) site and deploy it
     to [netlify](https://www.netlify.com/).
+  - [Docker](#docker-based-workflow) - For custom workflows based on
+    docker containers.
+  - [Bioconductor](#bioconductor-friendly-workflow) - A CI workflow for
+    packages to be released on Bioconductor.
+  - [Forcing binaries](#forcing-binaries) - An environment variable to
+    always use binary packages.
   - [Managing secrets](#managing-secrets) - How to generate auth tokens
     and make them available to actions.
 
@@ -418,7 +426,7 @@ issue comments. `/document` will use
 the package and commit the result to the pull request. `/style` will use
 [styler](https://styler.r-lib.org/) to restyle your package.
 
-## When it can they be used?
+### When should you use it?
 
 1.  You get frequent pull requests, often with documentation only fixes.
 2.  You regularly style your code with styler, and require all additions


### PR DESCRIPTION
This PR adds sections to the TOC of the examples README that were missing before. 

It includes the changes from commit 2ff8d11b8cdc657be1b2e8877ed03081746ec590, which were applied to README.md instead of README.Rmd and therefore were overwritten later. 