### PR TITLE
Disable crayon in bookdown example

### DIFF
--- a/examples/bookdown.yaml
+++ b/examples/bookdown.yaml
@@ -17,6 +17,9 @@ jobs:
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v1
+        with:
+          # To disable crayon coloring in chunk outputs
+          crayon.enabled: 'FALSE'
 
       - name: Install pandoc and pandoc citeproc
         run: |


### PR DESCRIPTION
`crayon.enabled` is TRUE in setup-r
https://github.com/r-lib/actions/blob/9598b8eeb6d88de7d76d580d84443542bbfdffce/setup-r/action.yml#L14-L16
and it seems this cause issue when building bookdown
https://stackoverflow.com/questions/64823120/bookdown-document-not-rendering-outputs-correctly

not the first. And those who knows has already set the option to FALSE, either as R option or in the setup-r action
* https://github.com/hadley/mastering-shiny/blob/de0620d3b1501f9f02a252f97e5a1b2c1ce0f15b/common.R#L21-L22
* https://github.com/ThinkR-open/engineering-shiny-book/blob/318018ee813864940ed2fc46dec8a8a3ba71c528/.github/workflows/deploy_bookdown.yml#L18-L20
* https://github.com/tidymodels/TMwR/blob/87997bc5de96afc8b793fca646d1a9f39b946572/_common.R#L4

I think we could set this option explicitly to FALSE in the example action. What do you think ? 

cc @ apreshill