### PR TITLE
Fix typo in matrix testing example

### DIFF
--- a/setup-r/README.md
+++ b/setup-r/README.md
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Setup R
-        uses: r-lib/actions/setup-R@v1
+        uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.R }}
       - run: Rscript -e 'print("hello")'


### PR DESCRIPTION
My workflow failed when I followed the Matrix Testing Example in the README due to a typo in the example: 
`uses: r-lib/actions/setup-R@v1` should be with a lowercase "r": `uses: r-lib/actions/setup-r@v1`