### PR TITLE
install package in lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -41,6 +41,9 @@ jobs:
           remotes::install_cran("lintr")
         shell: Rscript {0}
 
+      - name: Install package
+        run: R CMD INSTALL .
+
       - name: Lint
         run: lintr::lint_package()
         shell: Rscript {0}

--- a/examples/README.md
+++ b/examples/README.md
@@ -416,6 +416,9 @@ jobs:
           remotes::install_cran("lintr")
         shell: Rscript {0}
 
+      - name: Install package
+        run: R CMD INSTALL .
+
       - name: Lint
         run: lintr::lint_package()
         shell: Rscript {0}

--- a/examples/lint.yaml
+++ b/examples/lint.yaml
@@ -41,6 +41,9 @@ jobs:
           remotes::install_cran("lintr")
         shell: Rscript {0}
 
+      - name: Install package
+        run: R CMD INSTALL .
+
       - name: Lint
         run: lintr::lint_package()
         shell: Rscript {0}


### PR DESCRIPTION
The lintr workflow is missing an "Install package" workflow, if I am not mistaken, i.e. install the package, which is to be linted. 

At least, this is required in the travis workflow according to the [lintr README](https://github.com/jimhester/lintr/blob/master/README.md#L176).

In addition I had `no visible global function definition` or `no visible binding for global variable` lint warnings for internal functions without the package installed, which I don't have anymore with the package installed. I have the same behaviour locally, i.e. warnings without the package installed, no warnings with it installed. 