### PR TITLE
Add info about `renv::snapshot()`, fix typo

### DIFF
--- a/examples/README.Rmd
+++ b/examples/README.Rmd
@@ -137,7 +137,7 @@ print_yaml("pkgdown.yaml")
 
 This example builds a [bookdown] site for a repository and then deploys the site via [netlify].
 It uses [renv] to ensure the package versions remain consistent across builds.
-You will need to run `renv::snapshot()` locally and commit the `renv.lock` file before using this workflow, see [Using renv with Continous Integeration](https://rstudio.github.io/renv/articles/ci.html) for additional information.
+You will need to run `renv::snapshot()` locally and commit the `renv.lock` file before using this workflow, and after every time you add a new package to `DESCRIPTION`. See [Using renv with Continous Integration](https://rstudio.github.io/renv/articles/ci.html) for additional information.
 **Note** you need to add a `NETLIFY_AUTH_TOKEN` and a `NETLIFY_SITE_ID` secret to your repository for the netlify deploy (see [Managing secrets](#managing-secrets) section for details).
 
 ```{r echo = FALSE, results = "asis"}


### PR DESCRIPTION
`renv::snapshot()` needs to be run locally every time packages in DESCRIPTION is changed, fix typo (Integeration should be Integration).