### PR TITLE
Consider adding the -y flag 

### DIFF
--- a/setup-r/lib/installer.js
+++ b/setup-r/lib/installer.js
@@ -186,9 +186,9 @@ function acquireRUbuntu(version) {
         try {
             // Important backports needed for CRAN packages, including libgit2
             yield exec.exec("sudo DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:cran/travis");
-            yield exec.exec("sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq");
+            yield exec.exec("sudo DEBIAN_FRONTEND=noninteractive apt-get update -y -qq");
             // install gdbi-core and also qpdf, which is used by `--as-cran`
-            yield exec.exec("sudo DEBIAN_FRONTEND=noninteractive apt-get install gdebi-core qpdf devscripts");
+            yield exec.exec("sudo DEBIAN_FRONTEND=noninteractive apt-get install -y gdebi-core qpdf devscripts");
             yield exec.exec("sudo gdebi", [
                 "--non-interactive",
                 path.join(tempDirectory, fileName)

--- a/setup-r/src/installer.ts
+++ b/setup-r/src/installer.ts
@@ -154,10 +154,12 @@ async function acquireRUbuntu(version: string): Promise<string> {
       "sudo DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:cran/travis"
     );
 
-    await exec.exec("sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq");
+    await exec.exec(
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get update -y -qq"
+    );
     // install gdbi-core and also qpdf, which is used by `--as-cran`
     await exec.exec(
-      "sudo DEBIAN_FRONTEND=noninteractive apt-get install gdebi-core qpdf devscripts"
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y gdebi-core qpdf devscripts"
     );
     await exec.exec("sudo gdebi", [
       "--non-interactive",


### PR DESCRIPTION
I am using the setup-r actions in a container action. The container image is quite raw, and `apt-get install` statement will try to install suggested packages and will prompt for permissions even with `DEBIAN_FRONTEND=noninteractive` set.

Here's an example where it blocks in the prompt: https://github.com/mlverse/tabnet/runs/1688281651?check_suite_focus=true#step:5:148

Adding the `-y` flag, fixes this issue.