### PR TITLE
Replace use of brew cask in setup-r

### DIFF
--- a/setup-r/lib/installer.js
+++ b/setup-r/lib/installer.js
@@ -123,7 +123,7 @@ function acquireR(version, rtoolsVersion) {
 function acquireFortranMacOS() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            yield exec.exec("brew", ["cask", "install", "gfortran"]);
+            yield exec.exec("brew", ["install", "--cask", "gfortran"]);
         }
         catch (error) {
             core.debug(error);

--- a/setup-r/lib/installer.js
+++ b/setup-r/lib/installer.js
@@ -123,7 +123,7 @@ function acquireR(version, rtoolsVersion) {
 function acquireFortranMacOS() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            yield exec.exec("brew", ["install", "--cask", "gfortran"]);
+            yield exec.exec("brew", ["install", "gcc"]);
         }
         catch (error) {
             core.debug(error);

--- a/setup-r/src/installer.ts
+++ b/setup-r/src/installer.ts
@@ -89,7 +89,7 @@ async function acquireR(version: string, rtoolsVersion: string) {
 
 async function acquireFortranMacOS() {
   try {
-    await exec.exec("brew", ["install", "--cask", "gfortran"]);
+    await exec.exec("brew", ["install", "gcc"]);
   } catch (error) {
     core.debug(error);
 

--- a/setup-r/src/installer.ts
+++ b/setup-r/src/installer.ts
@@ -89,7 +89,7 @@ async function acquireR(version: string, rtoolsVersion: string) {
 
 async function acquireFortranMacOS() {
   try {
-    await exec.exec("brew", ["cask", "install", "gfortran"]);
+    await exec.exec("brew", ["install", "--cask", "gfortran"]);
   } catch (error) {
     core.debug(error);
 


### PR DESCRIPTION
Hi, I've just moved a package repo ([XLConnect](https://github.com/miraisolutions/xlconnect)) to Github actions, worked very well - thanks for this project!

Homebrew version [2.6.0](https://github.com/Homebrew/brew/releases/tag/2.6.0) deprecated `brew cask` commands on 2020-12-1, then disabled them with version [2.7.0](https://github.com/Homebrew/brew/releases/tag/2.7.0) on 2020-12-21.

My tests using **macos-10.15** were not successful using _gfortran_ in the install command (with or without `--cask`), but using _gcc_ worked, which is equivalent (see [formula](https://formulae.brew.sh/formula/gcc#default) page)

Let me know if I should change something / open a matching issue.