### PR TITLE
Install gfortran from mac.r-project.org

### DIFF
--- a/setup-r/lib/installer.js
+++ b/setup-r/lib/installer.js
@@ -175,7 +175,7 @@ function acquireFortranMacOS() {
 
             throw `Failed to umount ${mntPath}: ${error}`;
           }
-
+        core.addPath("/usr/local/gfortran/bin");
         return "/";
     });
 }

--- a/setup-r/src/installer.ts
+++ b/setup-r/src/installer.ts
@@ -142,7 +142,7 @@ async function acquireFortranMacOS(): Promise<string> {
 
     throw `Failed to umount ${mntPath}: ${error}`;
   }
-
+  core.addPath("/usr/local/gfortran/bin");
   return "/";
 }
 


### PR DESCRIPTION
Hi folks,

This PR fixes issue when linking to fortran libs introduced in #229. Moreover it in theory should enhance  robustness of the r-setup as it uses "official" gfortran (which is used during R binaries build). I'm not sure if fortran libs from gcc-10 from brew was safe to use with R built with another fortran version.