### PR TITLE
configure.ac line ending fix for windows

### DIFF
--- a/examples/check-full.yaml
+++ b/examples/check-full.yaml
@@ -43,6 +43,9 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
+      - name: Windows CRLF fix
+        run: git config --global core.autocrlf false
+
       - uses: actions/checkout@v2
 
       - uses: r-lib/actions/setup-r@v1


### PR DESCRIPTION
If the package contains a configure.ac file, the check on windows will error even if line endings are properly formatted with LF. 

See: https://msmith.de/2020/03/12/r-cmd-check-github-actions.html