### PR TITLE
Avoid installing R

### DIFF
--- a/.github/workflows/pkgdown-pak.yaml
+++ b/.github/workflows/pkgdown-pak.yaml
@@ -18,6 +18,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r@master
         id: install-r
+        with:
+          install-r: false
 
       - uses: r-lib/actions/setup-pandoc@master
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: r-lib/actions/setup-r@master
+        with:
+          install-r: false
 
       - uses: r-lib/actions/setup-pandoc@master
 

--- a/.github/workflows/test-coverage-pak.yaml
+++ b/.github/workflows/test-coverage-pak.yaml
@@ -22,6 +22,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r@master
         id: install-r
+        with:
+          install-r: false
 
       - name: Install pak and query dependencies
         run: |

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: r-lib/actions/setup-r@master
+        with:
+          install-r: false
 
       - uses: r-lib/actions/setup-pandoc@master
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -365,6 +365,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: r-lib/actions/setup-r@v1
+        with:
+          install-r: false
 
       - uses: r-lib/actions/setup-pandoc@v1
 
@@ -602,6 +604,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: r-lib/actions/setup-r@v1
+        with:
+          install-r: false
 
       - uses: r-lib/actions/setup-pandoc@v1
 

--- a/examples/pkgdown-pak.yaml
+++ b/examples/pkgdown-pak.yaml
@@ -18,6 +18,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v1
         id: install-r
+        with:
+          install-r: false
 
       - uses: r-lib/actions/setup-pandoc@v1
 

--- a/examples/pkgdown.yaml
+++ b/examples/pkgdown.yaml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: r-lib/actions/setup-r@v1
+        with:
+          install-r: false
 
       - uses: r-lib/actions/setup-pandoc@v1
 

--- a/examples/test-coverage-pak.yaml
+++ b/examples/test-coverage-pak.yaml
@@ -22,6 +22,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v1
         id: install-r
+        with:
+          install-r: false
 
       - name: Install pak and query dependencies
         run: |

--- a/examples/test-coverage.yaml
+++ b/examples/test-coverage.yaml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: r-lib/actions/setup-r@v1
+        with:
+          install-r: false
 
       - uses: r-lib/actions/setup-pandoc@v1
 


### PR DESCRIPTION
when the default version will do just fine.

Saves some time for each build, ultimately increases concurrency.