### PR TITLE
add -f when creating symlinks otherwise they may fail

### DIFF
--- a/setup-r/src/installer.ts
+++ b/setup-r/src/installer.ts
@@ -230,12 +230,12 @@ async function acquireRUbuntu(version: string): Promise<string> {
   //
   try {
     await exec.exec("sudo ln", [
-      "-s",
+      "-sf",
       path.join("/opt", "R", version, "bin", "R"),
       "/usr/local/bin/R"
     ]);
     await exec.exec("sudo ln", [
-      "-s",
+      "-sf",
       path.join("/opt", "R", version, "bin", "Rscript"),
       "/usr/local/bin/Rscript"
     ]);


### PR DESCRIPTION
The `setup-r` action fails if `/usr/local/bin/R` and/or `/usr/local/bin/Rscript` already exists (either due to another action or previous run on self-hosted runners). Adding `-f` to `ln` fixes it.