### PR TITLE
Add a FAQ entry for `configure.ac` CRLF line endings on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ If your build fails and you are unsure of why here are some useful strategies fo
 1. *Does GitHub Actions support `[ci skip]` or similar syntax to automatically skip a build?*\
   Not by default, however you can enable it in any of your workflows by adding the following [conditional](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idif), e.g. \
   `if: !contains(github.event.head_commit.message, '[ci skip]')`
+1. *Why are my Windows builds failing with an error about `configure.ac` having CRLF line endings?*\
+  On Windows, when your repo is checked out using git the line endings are automatically changed to CRLF. R's check process specifically checks if the `configure.ac` file has these line endings, and will error if it does. To avoid this, add the following step before the `actions/checkout` step to configure git to not alter these line endings:\
+   ```
+   - name: Windows CRLF fix
+     run: git config --global core.autocrlf false
+   ```
+  
 
 ## Additional resources
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,8 @@ If your build fails and you are unsure of why here are some useful strategies fo
   Not by default, however you can enable it in any of your workflows by adding the following [conditional](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idif), e.g. \
   `if: !contains(github.event.head_commit.message, '[ci skip]')`
 1. *Why are my Windows builds failing with an error about `configure.ac` having CRLF line endings?*\
-  On Windows, when your repo is checked out using git the line endings are automatically changed to CRLF. R's check process specifically checks if the `configure.ac` file has these line endings, and will error if it does. To avoid this, add the following step before the `actions/checkout` step to configure git to not alter these line endings:\
-   ```
-   - name: Windows CRLF fix
-     run: git config --global core.autocrlf false
-   ```
+  On Windows, when your repo is checked out using git the line endings are automatically changed to CRLF. R's check process specifically checks if the `configure.ac` file has these line endings, and will error if it does. To avoid this, add a `.gitattributes` file to the top level of your package with the following to configure git to always use LF line endings for this file: \
+  `configure.ac text eol=lf`
   
 
 ## Additional resources


### PR DESCRIPTION
Closes #256 

We had this issue in https://github.com/topepo/Cubist/pull/35

We stumbled across [the blog post mentioned in #256](https://msmith.de/2020/03/12/r-cmd-check-github-actions.html), but a FAQ entry here would have been better, I think.