### PR TITLE
add update-rtools option

### DIFF
--- a/setup-r/action.yml
+++ b/setup-r/action.yml
@@ -31,6 +31,9 @@ inputs:
     description: 'If "true" put the 64 bit mingw directory from Rtools on the
     PATH for Windows builds'
     default: true
+  update-rtools:
+    description: 'Update rtools40 compilers and libraries to the latest builds'
+    default: false
 outputs:
   installed-r-version:
     description: 'The full R version installed'

--- a/setup-r/lib/installer.js
+++ b/setup-r/lib/installer.js
@@ -251,12 +251,12 @@ function acquireRUbuntu(version) {
         //
         try {
             yield exec.exec("sudo ln", [
-                "-s",
+                "-sf",
                 path.join("/opt", "R", version, "bin", "R"),
                 "/usr/local/bin/R"
             ]);
             yield exec.exec("sudo ln", [
-                "-s",
+                "-sf",
                 path.join("/opt", "R", version, "bin", "Rscript"),
                 "/usr/local/bin/Rscript"
             ]);
@@ -379,6 +379,15 @@ function acquireRtools(version) {
             core.addPath(`C:\\rtools40\\usr\\bin`);
             if (core.getInput("windows-path-include-mingw") === "true") {
                 core.addPath(`C:\\rtools40\\mingw64\\bin`);
+            }
+            if (core.getInput("update-rtools") === "true") {
+                try {
+                    yield exec.exec("c:\\rtools40\\usr\\bin\\bash.exe", ["--login", "-c", "pacman -Syu --noconfirm"]);
+                }
+                catch (error) {
+                    core.debug(error);
+                    throw `Failed to update rtools40 libraries: ${error}`;
+                }
             }
         }
         else {

--- a/setup-r/package-lock.json
+++ b/setup-r/package-lock.json
@@ -2171,6 +2171,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/setup-r/src/installer.ts
+++ b/setup-r/src/installer.ts
@@ -375,6 +375,14 @@ async function acquireRtools(version: string) {
     if (core.getInput("windows-path-include-mingw") === "true") {
       core.addPath(`C:\\rtools40\\mingw64\\bin`);
     }
+    if (core.getInput("update-rtools") === "true") {
+      try {
+        await exec.exec("c:\\rtools40\\usr\\bin\\bash.exe", ["--login", "-c", "pacman -Syu --noconfirm"]);
+      } catch (error) {
+        core.debug(error);
+        throw `Failed to update rtools40 libraries: ${error}`;
+      }
+    }
   } else {
     core.addPath(`C:\\Rtools\\bin`);
     if (core.getInput("windows-path-include-mingw") === "true") {


### PR DESCRIPTION
@ijlyttle @yutannihilation @clauswilke this should fix your immediate issue with rust.

Introduces an option to update rtools to the latest builds of gcc and libraries. This is mainly useful for the preinstalled rtools40 installations on the GHA image.