### PR TITLE
Don't worry about missing pak dependencies

### DIFF
--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -16,6 +16,7 @@ runs:
       - name: Install pak and query dependencies
         run: |
           cat("::group::Install pak")
+          options(pak.no_extra_messages = TRUE)
           install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev/")
           saveRDS(pak::pkg_deps("local::.", dependencies = TRUE), ".github/r-depends.rds")
         shell: Rscript {0}


### PR DESCRIPTION
This eliminates the message:

```
! Optional package `tibble` is not available for pak.
  Use `pak::pak_install_extra()` to install optional packages.
  Use `options(pak.no_extra_messages = TRUE)` to suppress this message.
```