### PR TITLE
Experimental support for R-devel-ucrt

### DIFF
--- a/setup-r/lib/installer.js
+++ b/setup-r/lib/installer.js
@@ -380,6 +380,7 @@ function acquireRtools(version) {
             core.addPath(`C:\\rtools40\\usr\\bin`);
             if (core.getInput("r-version").match("ucrt")) {
                 core.addPath(`C:\\rtools40\\ucrt64\\bin`);
+                core.exportVariable("_R_INSTALL_TIME_PATCHES_", "no");
             }
             else if (core.getInput("windows-path-include-mingw") === "true") {
                 core.addPath(`C:\\rtools40\\mingw64\\bin`);
@@ -468,6 +469,7 @@ function setupRLibrary() {
         }
         yield fs.promises.writeFile(profilePath, `options(
   repos = c(
+    ${core.getInput("r-version").match("ucrt") ? `CRAN_UCRT = "https://www.r-project.org/nosvn/winutf8/ucrt3/CRAN",` : ''}
     RSPM = ${rspm},
     CRAN = ${cran}
   ),

--- a/setup-r/lib/installer.js
+++ b/setup-r/lib/installer.js
@@ -378,7 +378,10 @@ function acquireRtools(version) {
         }
         if (rtools4) {
             core.addPath(`C:\\rtools40\\usr\\bin`);
-            if (core.getInput("windows-path-include-mingw") === "true") {
+            if (core.getInput("r-version").match("ucrt")) {
+                core.addPath(`C:\\rtools40\\ucrt64\\bin`);
+            }
+            else if (core.getInput("windows-path-include-mingw") === "true") {
                 core.addPath(`C:\\rtools40\\mingw64\\bin`);
             }
             if (core.getInput("update-rtools") === "true") {
@@ -522,6 +525,9 @@ function getDownloadUrlWindows(version) {
     return __awaiter(this, void 0, void 0, function* () {
         if (version == "devel") {
             return "https://cloud.r-project.org/bin/windows/base/R-devel-win.exe";
+        }
+        if (version == "devel-ucrt") {
+            return "https://cloud.r-project.org/bin/windows/testing/R-devel-ucrt.exe";
         }
         const filename = getFileNameWindows(version);
         const releaseVersion = yield getReleaseVersion("win");

--- a/setup-r/src/installer.ts
+++ b/setup-r/src/installer.ts
@@ -373,7 +373,9 @@ async function acquireRtools(version: string) {
   }
   if (rtools4) {
     core.addPath(`C:\\rtools40\\usr\\bin`);
-    if (core.getInput("windows-path-include-mingw") === "true") {
+    if (core.getInput("r-version").match("ucrt")) {
+      core.addPath(`C:\\rtools40\\ucrt64\\bin`);
+    } else if (core.getInput("windows-path-include-mingw") === "true") {
       core.addPath(`C:\\rtools40\\mingw64\\bin`);
     }
     if (core.getInput("update-rtools") === "true") {
@@ -547,6 +549,9 @@ function getFileNameWindows(version: string): string {
 async function getDownloadUrlWindows(version: string): Promise<string> {
   if (version == "devel") {
     return "https://cloud.r-project.org/bin/windows/base/R-devel-win.exe";
+  }
+  if (version == "devel-ucrt") {
+    return "https://cloud.r-project.org/bin/windows/testing/R-devel-ucrt.exe";
   }
 
   const filename: string = getFileNameWindows(version);

--- a/setup-r/src/installer.ts
+++ b/setup-r/src/installer.ts
@@ -375,6 +375,7 @@ async function acquireRtools(version: string) {
     core.addPath(`C:\\rtools40\\usr\\bin`);
     if (core.getInput("r-version").match("ucrt")) {
       core.addPath(`C:\\rtools40\\ucrt64\\bin`);
+      core.exportVariable("_R_INSTALL_TIME_PATCHES_", "no");
     } else if (core.getInput("windows-path-include-mingw") === "true") {
       core.addPath(`C:\\rtools40\\mingw64\\bin`);
     }
@@ -471,6 +472,7 @@ async function setupRLibrary() {
     profilePath,
     `options(
   repos = c(
+    ${core.getInput("r-version").match("ucrt") ? `CRAN_UCRT = "https://www.r-project.org/nosvn/winutf8/ucrt3/CRAN",` : '' }
     RSPM = ${rspm},
     CRAN = ${cran}
   ),


### PR DESCRIPTION
Minimal changes to start testing with `r-version: devel-ucrt`, which may be useful for packages with compiled code.

Here is an example run: https://github.com/r-lib/gert/runs/3533720768
