### PR TITLE
Fix bug in render_rmarkdown.yml example.

### DIFF
--- a/examples/render-rmarkdown.yaml
+++ b/examples/render-rmarkdown.yaml
@@ -17,12 +17,12 @@ jobs:
         with:
           fetch-depth: 0
 
-        uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v1
 
-        uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v1
 
-        uses: r-lib/actions/setup-renv@v1
-
+      - uses: r-lib/actions/setup-renv@v1
+      
       - name: Render Rmarkdown files
         run: |
           RMD_PATH=($(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '[.]Rmd$'))


### PR DESCRIPTION
The example for rendering_rmarkdown appears to have a bug. It has multiple `uses` without a preceding hyphen which leads to an error as shown in the link below - 

https://github.com/oshanmodi/demo_repo_for_errors/actions/runs/1275789217

This update should fix that. There is also a missing rmarkdown package that's needed prior to rendering the .Rmd, the update does not address that.
