### PR TITLE
Fix the setup-renv action

### DIFF
--- a/setup-renv/action.yaml
+++ b/setup-renv/action.yaml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - name: Install renv and query dependencies
+      - name: Install renv
         run: |
           install.packages("renv")
         shell: Rscript {0}


### PR DESCRIPTION
We don't need to install renv twice, and we should use Rscript to run `renv::restore()`.

Fixes https://github.com/r-lib/actions/issues/403