### PR TITLE
(setup-renv) Fix Renv package cache location

### DIFF
--- a/setup-renv/action.yaml
+++ b/setup-renv/action.yaml
@@ -9,9 +9,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - name: Install renv
+      - name: Install and activate renv
         run: |
           install.packages("renv")
+          renv::activate()
         shell: Rscript {0}
 
       - name: Get R and OS version
@@ -24,13 +25,13 @@ runs:
       - name: Get renv cache path
         id: get-renv-cache-path
         run: |
-          cat("##[set-output name=renv-cache-path;]", renv:::paths$cache(), sep = "")
+          cat("##[set-output name=renv-cache-path;]", renv::paths$cache(), sep = "")
         shell: Rscript {0}
 
       - name: Restore Renv package cache
         uses: actions/cache@v2
         with:
-          path: ${{ steps.get-renv-cache-path.renv-cache-path }}
+          path: ${{ steps.get-renv-cache-path.outputs.renv-cache-path }}
           key: ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-${{inputs.cache-version }}-${{ hashFiles('renv.lock') }}
           restore-keys: ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-${{inputs.cache-version }}-
 


### PR DESCRIPTION
Hi all,
This PR changes the Renv package cache location by using `renv::paths$cache()`. In the latest update of renv v0.14.0 the default path to the global renv cache has changed. See [the renv release notes](https://github.com/rstudio/renv/blob/master/NEWS.md#renv-0140) and [commit for more details](https://github.com/rstudio/renv/commit/758e9fd4be8aed72220388ea27b562bcef249710#diff-eb1ccebc1cc8dc359bd2cbc7e7ca5d19eb2abd37519f5368437457228df03705R252).

This PR fixes https://github.com/r-lib/actions/issues/408. I also opened a PR on the `actions/cache` repository so they can update their examples readme accordingly. See https://github.com/actions/cache/pull/660 for more details.

The documentation on [the Rstudio documentation](https://rstudio.github.io/renv/articles/renv.html#cache) should probably also be updated with the new cache locations. See:

<img width="513" alt="Screenshot 2021-10-14 at 13 49 08" src="https://user-images.githubusercontent.com/1810384/137311890-d4f5528b-9024-4bc9-b802-442534e2ec02.png">

Kind regards,
Manuel