### PR TITLE
(setup-renv) Fix renv package cache location

### DIFF
--- a/setup-renv/action.yaml
+++ b/setup-renv/action.yaml
@@ -9,9 +9,15 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - name: Install renv
+      - name: Set RENV_PATHS_ROOT
+        shell: bash
+        run: |
+          echo "RENV_PATHS_ROOT=${{ runner.temp }}/renv" >> $GITHUB_ENV
+
+      - name: Install and activate renv
         run: |
           install.packages("renv")
+          renv::activate()
         shell: Rscript {0}
 
       - name: Get R and OS version
@@ -24,7 +30,7 @@ runs:
       - name: Restore Renv package cache
         uses: actions/cache@v2
         with:
-          path: $HOME/.local/share/renv
+          path: ${{ env.RENV_PATHS_ROOT }}
           key: ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-${{inputs.cache-version }}-${{ hashFiles('renv.lock') }}
           restore-keys: ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-${{inputs.cache-version }}-
 


### PR DESCRIPTION
This PR fixes the renv package location by setting the `RENV_PATHS_ROOT` environment variable to `${{ runner.temp }}/renv`, as suggested by https://github.com/r-lib/actions/pull/410#issuecomment-943513162. This should ensure the correct directory is being cached on the GHA runner.

Fixes #408.