### PR TITLE
Allow selecting pak version in setup-dependencies

### DIFF
--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -10,6 +10,9 @@ inputs:
     description: 'Any extra packages to install outside of the packages listed in the dependencies'
   needs:
     description: 'Any extra Config/Needs fields which need to be included when installing dependencies'
+  pak-version:
+    description: 'Which pak version to use. Possible values are "stable", "rc" and "devel".'
+    default: 'stable'
 runs:
   using: "composite"
   steps:
@@ -17,7 +20,7 @@ runs:
         run: |
           cat("::group::Install pak\n")
           options(pak.no_extra_messages = TRUE)
-          install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev/")
+          install.packages("pak", repos = "https://r-lib.github.io/p/pak/{{ inputs.pak-version }}/")
           saveRDS(pak::pkg_deps("local::.", dependencies = TRUE), ".github/r-depends.rds")
         shell: Rscript {0}
 


### PR DESCRIPTION
Currently they all point to the same version, but soon (tomorrow) `devel` will be the nightly build, and `stable` will be the CRAN version after the next release.

The previously hardcoded `dev` folder is now a symlink to `rc` and will be kept, for compatibility with existing workflow files.

Does this make sense?