### PR TITLE
Use GH sessioninfo temporarily

### DIFF
--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -56,7 +56,7 @@ runs:
               pak::pkg_system_requirements(dep, execute = TRUE)
             }
           }
-          pak::pkg_install(c(local_deps, needs_only_deps, extra_deps, "sessioninfo"))
+          pak::pkg_install(c(local_deps, needs_only_deps, extra_deps, "r-lib/sessioninfo@a68df12"))
           cat("::endgroup::\n")
         shell: Rscript {0}
 
@@ -64,8 +64,7 @@ runs:
         run: |
           cat("::group::Session info\n")
           options(width = 100)
-          pkgs <- installed.packages()[, "Package"]
-          sessioninfo::session_info(pkgs, include_base = TRUE)
+          sessioninfo::session_info("!installed", include_base = TRUE)
           cat("::endgroup::\n")
         shell: Rscript {0}
 


### PR DESCRIPTION
Because new CRAN sessioninfo fails if there are some broken installations in the library.

I am not sure how to fix the `v1` tag, maybe we could just point the tag to the fix?