### PR TITLE
Add `working-directory` input to `check-r-package` action

### DIFF
--- a/check-r-package/README.md
+++ b/check-r-package/README.md
@@ -6,6 +6,14 @@ This action checks an R package using the [rcmdcheck](https://r-lib.github.io/rc
 
 # Usage
 
+Inputs available:
+- description - default `"--no-manual", "--as-cran"`. Arguments to pass to the `args` parameter of `rcmdcheck`
+- build_args - default `""`. Arguments to pass to the `build_args` parameter of `rcmdcheck`
+- error-on - default `"warning"`. Arguments to pass to the `error-on` parameter of `rcmdcheck`
+- check-dir - default `"check"`. Arguments to pass to the `check-dir` parameter of `rcmdcheck`
+- working-directory - default `"."`. If the R package to check is not in the root directory of your repository.
+
+Basic: 
 ```yaml
 steps:
 - uses: actions/checkout@master

--- a/check-r-package/action.yaml
+++ b/check-r-package/action.yaml
@@ -14,8 +14,15 @@ inputs:
   check-dir:
     description: 'Where should the check output go?'
     default: '"check"'
+  working-directory:
+    description: 'Using the working-directory keyword, you can specify the working directory of where "rcmdcheck::rcmdcheck" is run.
+    default: '.'
+    
 runs:
   using: "composite"
+  defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
   steps:
     - name: Check
       env:


### PR DESCRIPTION
This is an extension to #438 based on a request from @riccardoporreca.

I believe this PR is self explanatory. Working on checking these changes on my repo.

Looking for comments and feedback.