### PR TITLE
Do not install the package itself

### DIFF
--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -60,7 +60,7 @@ runs:
               pak::pkg_system_requirements(dep, execute = TRUE)
             }
           }
-          pak::pkg_install(c(local_deps, needs_only_deps, extra_deps, "sessioninfo"))
+          pak::pkg_install(c(local_deps[-1], needs_only_deps, extra_deps, "sessioninfo"))
           cat("::endgroup::\n")
         shell: Rscript {0}
         working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
This speeds up substantially the checks for compiled packages. Should this be an option? Can we rely on pak's behavior to list the target package first?

CC @gaborcsardi.