### PR TITLE
[setup-tinytex] Add information about env var to configure to change downloaded version

### DIFF
--- a/setup-tinytex/README.md
+++ b/setup-tinytex/README.md
@@ -43,6 +43,42 @@ steps:
       tlmgr list --only-installed
 ```
 
+## TinyTeX bundled release
+
+TinyTeX is available as several bundles from https://github.com/yihui/tinytex-releases/. 
+
+By default, the action will install the same bundle as
+`tinytex::install_tinytex()` which is the daily build of _TinyTeX-1_ bundle.
+This bundles contains the TinyTeX distribution and a set of CTAN packages. The
+_TinyTeX_ bundles comes with more CTAN packages bundled.
+
+To change the bundle to install you can change the environment variable
+`TINYTEX_INSTALLER`
+
+````yaml
+      - uses: r-lib/actions/setup-tinytex@v1
+        env:
+          # install full prebuilt version
+          TINYTEX_INSTALLER: TinyTeX
+````
+
+In addition to the daily commonly used, TinyTeX is also built in monthly
+releases. You can find all the releases in
+https://github.com/yihui/tinytex-releases/releases
+
+To install a specific version, you can set the `TINYTEX_VERSION` environment variable
+
+````yaml
+      - uses: r-lib/actions/setup-tinytex@v1
+        env:
+          # always install the bundled version from Nov. 2021
+          TINYTEX_VERSION: 2021-11
+````
+
+See more on those bundles in [`yihui/tinytex-releases`
+README](https://github.com/yihui/tinytex-releases#releases), especially the list
+of bundled CTAN packages.
+
 # License
 
 The scripts and documentation in this project are released under the [MIT License](LICENSE)


### PR DESCRIPTION
This PR adds some context about TinyTeX bundle releases that one can install using this action. 

I don't know if this is better to set this before CTAN package or not. I put it after. Feel free to inverse.  