### PR TITLE
Add document and style workflows

### DIFF
--- a/examples/README.Rmd
+++ b/examples/README.Rmd
@@ -144,6 +144,16 @@ package.
 print_yaml("pr-commands.yaml")
 ```
 
+## Render Rmarkdown
+
+`usethis::use_github_action("render-rmarkdown")`
+
+This example automatically re-builds any Rmarkdown file in the repository whenever it changes and commits the results to the same branch.
+
+```{r echo = FALSE, results = "asis"}
+print_yaml("render-rmarkdown.yaml")
+```
+
 ## Build pkgdown site
 
 `usethis::use_github_action("pkgdown")`
@@ -178,16 +188,6 @@ to the same branch.
 print_yaml("style.yaml")
 ```
 
-## Render Rmarkdown
-
-`usethis::use_github_action("render-rmarkdown")`
-
-This example automatically re-builds any Rmarkdown file in the repository whenever it changes and commits the results to the same branch.
-
-```{r echo = FALSE, results = "asis"}
-print_yaml("render-rmarkdown.yaml")
-```
-
 ## Build bookdown site
 
 `usethis::use_github_action("bookdown")`
@@ -212,6 +212,22 @@ You will need to run `renv::snapshot()` locally and commit the `renv.lock` file 
 
 ```{r echo = FALSE, results = "asis"}
 print_yaml("blogdown.yaml")
+```
+
+## Shiny App Deployment
+
+`usethis::use_github_action("shiny-deploy")`
+
+This example will deploy your Shiny application to either [shinyapps.io](https://www.shinyapps.io/) or [RStudio Connect](https://www.rstudio.com/products/connect/) using the `rsconnect` package. The `rsconnect` package requires authorization to deploy an app using your account. This action does this by using your user name (`RSCONNECT_USER`), token (`RSCONNECT_TOKEN`), and secret (`RSCONNECT_SECRET`), which are securely accessed as GitHub Secrets. **Your token and secret are private and should be kept confidential**.
+
+This action assumes you have an `renv` lockfile in your repository that describes the `R` packages and versions required for your Shiny application.
+
+- See here for information on how to obtain the token and secret for configuring `rsconnect`: https://shiny.rstudio.com/articles/shinyapps.html
+
+- See here for information on how to store private tokens in a repository as GitHub Secrets: https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository
+
+```{r echo = FALSE, results = "asis"}
+print_yaml("shiny-deploy.yaml")
 ```
 
 ## Docker based workflow
@@ -263,22 +279,6 @@ This example uses the [lintr](https://github.com/jimhester/lintr) package to lin
 
 ```{r echo = FALSE, results = "asis"}
 print_yaml("lint-project.yaml")
-```
-
-## Shiny App Deployment
-
-`usethis::use_github_action("shiny-deploy")`
-
-This example will deploy your Shiny application to either [shinyapps.io](https://www.shinyapps.io/) or [RStudio Connect](https://www.rstudio.com/products/connect/) using the `rsconnect` package. The `rsconnect` package requires authorization to deploy an app using your account. This action does this by using your user name (`RSCONNECT_USER`), token (`RSCONNECT_TOKEN`), and secret (`RSCONNECT_SECRET`), which are securely accessed as GitHub Secrets. **Your token and secret are private and should be kept confidential**.
-
-This action assumes you have an `renv` lockfile in your repository that describes the `R` packages and versions required for your Shiny application.
-
-- See here for information on how to obtain the token and secret for configuring `rsconnect`: https://shiny.rstudio.com/articles/shinyapps.html
-
-- See here for information on how to store private tokens in a repository as GitHub Secrets: https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository
-
-```{r echo = FALSE, results = "asis"}
-print_yaml("shiny-deploy.yaml")
 ```
 
 

--- a/examples/README.Rmd
+++ b/examples/README.Rmd
@@ -21,6 +21,8 @@ Package workflows:
 - [`lint`](#lint-workflow) - Run `lintr::lint_package()` on an R package.
 - [`pr-commands`](#commands-workflow) - Adds `/document` and `/style` commands for pull requests.
 - [`pkgdown`](#build-pkgdown-site) - Build a [pkgdown] site for an R package and deploy it to [GitHub Pages].
+- [`document`](#document-package) - Run `roxygen2::roxygenise()` on an R package.
+- [`style`](#style-package) - Run `styler::style_pkg()` on an R package.
 
 RMarkdown workflows:
 
@@ -162,6 +164,28 @@ The inclusion of [`workflow_dispatch`](https://docs.github.com/en/actions/learn-
 
 ```{r echo = FALSE, results = "asis"}
 print_yaml("pkgdown.yaml")
+```
+
+## Document package
+
+`usethis::use_github_action("document")`
+
+This example documents an R package whenever a file in the `R/` directory changes, then commits and pushes the changes
+to the same branch.
+
+```{r echo = FALSE, results = "asis"}
+print_yaml("document.yaml")
+```
+
+## Style package
+
+`usethis::use_github_action("document")`
+
+This example styles the R code in a package, then commits and pushes the changes
+to the same branch.
+
+```{r echo = FALSE, results = "asis"}
+print_yaml("style.yaml")
 ```
 
 ## Build bookdown site

--- a/examples/README.Rmd
+++ b/examples/README.Rmd
@@ -144,16 +144,6 @@ package.
 print_yaml("pr-commands.yaml")
 ```
 
-## Render Rmarkdown
-
-`usethis::use_github_action("render-rmarkdown")`
-
-This example automatically re-builds any Rmarkdown file in the repository whenever it changes and commits the results to the same branch.
-
-```{r echo = FALSE, results = "asis"}
-print_yaml("render-rmarkdown.yaml")
-```
-
 ## Build pkgdown site
 
 `usethis::use_github_action("pkgdown")`
@@ -188,6 +178,16 @@ to the same branch.
 print_yaml("style.yaml")
 ```
 
+## Render Rmarkdown
+
+`usethis::use_github_action("render-rmarkdown")`
+
+This example automatically re-builds any Rmarkdown file in the repository whenever it changes and commits the results to the same branch.
+
+```{r echo = FALSE, results = "asis"}
+print_yaml("render-rmarkdown.yaml")
+```
+
 ## Build bookdown site
 
 `usethis::use_github_action("bookdown")`
@@ -212,22 +212,6 @@ You will need to run `renv::snapshot()` locally and commit the `renv.lock` file 
 
 ```{r echo = FALSE, results = "asis"}
 print_yaml("blogdown.yaml")
-```
-
-## Shiny App Deployment
-
-`usethis::use_github_action("shiny-deploy")`
-
-This example will deploy your Shiny application to either [shinyapps.io](https://www.shinyapps.io/) or [RStudio Connect](https://www.rstudio.com/products/connect/) using the `rsconnect` package. The `rsconnect` package requires authorization to deploy an app using your account. This action does this by using your user name (`RSCONNECT_USER`), token (`RSCONNECT_TOKEN`), and secret (`RSCONNECT_SECRET`), which are securely accessed as GitHub Secrets. **Your token and secret are private and should be kept confidential**.
-
-This action assumes you have an `renv` lockfile in your repository that describes the `R` packages and versions required for your Shiny application.
-
-- See here for information on how to obtain the token and secret for configuring `rsconnect`: https://shiny.rstudio.com/articles/shinyapps.html
-
-- See here for information on how to store private tokens in a repository as GitHub Secrets: https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository
-
-```{r echo = FALSE, results = "asis"}
-print_yaml("shiny-deploy.yaml")
 ```
 
 ## Docker based workflow
@@ -279,6 +263,22 @@ This example uses the [lintr](https://github.com/jimhester/lintr) package to lin
 
 ```{r echo = FALSE, results = "asis"}
 print_yaml("lint-project.yaml")
+```
+
+## Shiny App Deployment
+
+`usethis::use_github_action("shiny-deploy")`
+
+This example will deploy your Shiny application to either [shinyapps.io](https://www.shinyapps.io/) or [RStudio Connect](https://www.rstudio.com/products/connect/) using the `rsconnect` package. The `rsconnect` package requires authorization to deploy an app using your account. This action does this by using your user name (`RSCONNECT_USER`), token (`RSCONNECT_TOKEN`), and secret (`RSCONNECT_SECRET`), which are securely accessed as GitHub Secrets. **Your token and secret are private and should be kept confidential**.
+
+This action assumes you have an `renv` lockfile in your repository that describes the `R` packages and versions required for your Shiny application.
+
+- See here for information on how to obtain the token and secret for configuring `rsconnect`: https://shiny.rstudio.com/articles/shinyapps.html
+
+- See here for information on how to store private tokens in a repository as GitHub Secrets: https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository
+
+```{r echo = FALSE, results = "asis"}
+print_yaml("shiny-deploy.yaml")
 ```
 
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -423,53 +423,6 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-## Render Rmarkdown
-
-`usethis::use_github_action("render-rmarkdown")`
-
-This example automatically re-builds any Rmarkdown file in the
-repository whenever it changes and commits the results to the same
-branch.
-
-``` yaml
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
-on:
-  push:
-    paths: ['**.Rmd']
-
-name: render-rmarkdown
-
-jobs:
-  render-rmarkdown:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-renv@v2
-      
-      - name: Render Rmarkdown files
-        run: |
-          RMD_PATH=($(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '[.]Rmd$'))
-          Rscript -e 'for (f in commandArgs(TRUE)) if (file.exists(f)) rmarkdown::render(f)' ${RMD_PATH[*]}
-
-      - name: Commit results
-        run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git commit ${RMD_PATH[*]/.Rmd/.md} -m 'Re-build Rmarkdown files' || echo "No changes to commit"
-          git push origin || echo "No changes to commit"
-```
-
 ## Build pkgdown site
 
 `usethis::use_github_action("pkgdown")`
@@ -636,6 +589,53 @@ jobs:
           git push origin || echo "No changes to commit"
 ```
 
+## Render Rmarkdown
+
+`usethis::use_github_action("render-rmarkdown")`
+
+This example automatically re-builds any Rmarkdown file in the
+repository whenever it changes and commits the results to the same
+branch.
+
+``` yaml
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    paths: ['**.Rmd']
+
+name: render-rmarkdown
+
+jobs:
+  render-rmarkdown:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - uses: r-lib/actions/setup-renv@v2
+      
+      - name: Render Rmarkdown files
+        run: |
+          RMD_PATH=($(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '[.]Rmd$'))
+          Rscript -e 'for (f in commandArgs(TRUE)) if (file.exists(f)) rmarkdown::render(f)' ${RMD_PATH[*]}
+
+      - name: Commit results
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git commit ${RMD_PATH[*]/.Rmd/.md} -m 'Re-build Rmarkdown files' || echo "No changes to commit"
+          git push origin || echo "No changes to commit"
+```
+
 ## Build bookdown site
 
 `usethis::use_github_action("bookdown")`
@@ -759,67 +759,6 @@ jobs:
           folder: public
 ```
 
-## Shiny App Deployment
-
-`usethis::use_github_action("shiny-deploy")`
-
-This example will deploy your Shiny application to either
-[shinyapps.io](https://www.shinyapps.io/) or [RStudio
-Connect](https://www.rstudio.com/products/connect/) using the
-`rsconnect` package. The `rsconnect` package requires authorization to
-deploy an app using your account. This action does this by using your
-user name (`RSCONNECT_USER`), token (`RSCONNECT_TOKEN`), and secret
-(`RSCONNECT_SECRET`), which are securely accessed as GitHub Secrets.
-**Your token and secret are private and should be kept confidential**.
-
-This action assumes you have an `renv` lockfile in your repository that
-describes the `R` packages and versions required for your Shiny
-application.
-
--   See here for information on how to obtain the token and secret for
-    configuring `rsconnect`:
-    <https://shiny.rstudio.com/articles/shinyapps.html>
-
--   See here for information on how to store private tokens in a
-    repository as GitHub Secrets:
-    <https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository>
-
-``` yaml
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
-on:
-  push:
-    branches: [main, master]
-
-name: shiny-deploy
-
-jobs:
-  shiny-deploy:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-renv@v2
-
-      - name: Install rsconnect
-        run: install.packages("rsconnect")
-        shell: Rscript {0}
-
-      - name: Authorize and deploy app
-        run: |
-          rsconnect::setAccountInfo(${{ secrets.RSCONNECT_USER }}, ${{ secrets.RSCONNECT_TOKEN }}, ${{ secrets.RSCONNECT_SECRET }})
-          rsconnect::deployApp()
-        shell: Rscript {0}
-```
-
 ## Docker based workflow
 
 `usethis::use_github_action("docker")`
@@ -918,6 +857,67 @@ jobs:
 
       - name: Lint root directory
         run: lintr::lint_dir()
+        shell: Rscript {0}
+```
+
+## Shiny App Deployment
+
+`usethis::use_github_action("shiny-deploy")`
+
+This example will deploy your Shiny application to either
+[shinyapps.io](https://www.shinyapps.io/) or [RStudio
+Connect](https://www.rstudio.com/products/connect/) using the
+`rsconnect` package. The `rsconnect` package requires authorization to
+deploy an app using your account. This action does this by using your
+user name (`RSCONNECT_USER`), token (`RSCONNECT_TOKEN`), and secret
+(`RSCONNECT_SECRET`), which are securely accessed as GitHub Secrets.
+**Your token and secret are private and should be kept confidential**.
+
+This action assumes you have an `renv` lockfile in your repository that
+describes the `R` packages and versions required for your Shiny
+application.
+
+-   See here for information on how to obtain the token and secret for
+    configuring `rsconnect`:
+    <https://shiny.rstudio.com/articles/shinyapps.html>
+
+-   See here for information on how to store private tokens in a
+    repository as GitHub Secrets:
+    <https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository>
+
+``` yaml
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+
+name: shiny-deploy
+
+jobs:
+  shiny-deploy:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-renv@v2
+
+      - name: Install rsconnect
+        run: install.packages("rsconnect")
+        shell: Rscript {0}
+
+      - name: Authorize and deploy app
+        run: |
+          rsconnect::setAccountInfo(${{ secrets.RSCONNECT_USER }}, ${{ secrets.RSCONNECT_TOKEN }}, ${{ secrets.RSCONNECT_SECRET }})
+          rsconnect::deployApp()
         shell: Rscript {0}
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -423,6 +423,53 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+## Render Rmarkdown
+
+`usethis::use_github_action("render-rmarkdown")`
+
+This example automatically re-builds any Rmarkdown file in the
+repository whenever it changes and commits the results to the same
+branch.
+
+``` yaml
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    paths: ['**.Rmd']
+
+name: render-rmarkdown
+
+jobs:
+  render-rmarkdown:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - uses: r-lib/actions/setup-renv@v2
+      
+      - name: Render Rmarkdown files
+        run: |
+          RMD_PATH=($(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '[.]Rmd$'))
+          Rscript -e 'for (f in commandArgs(TRUE)) if (file.exists(f)) rmarkdown::render(f)' ${RMD_PATH[*]}
+
+      - name: Commit results
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git commit ${RMD_PATH[*]/.Rmd/.md} -m 'Re-build Rmarkdown files' || echo "No changes to commit"
+          git push origin || echo "No changes to commit"
+```
+
 ## Build pkgdown site
 
 `usethis::use_github_action("pkgdown")`
@@ -589,53 +636,6 @@ jobs:
           git push origin || echo "No changes to commit"
 ```
 
-## Render Rmarkdown
-
-`usethis::use_github_action("render-rmarkdown")`
-
-This example automatically re-builds any Rmarkdown file in the
-repository whenever it changes and commits the results to the same
-branch.
-
-``` yaml
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
-on:
-  push:
-    paths: ['**.Rmd']
-
-name: render-rmarkdown
-
-jobs:
-  render-rmarkdown:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-renv@v2
-      
-      - name: Render Rmarkdown files
-        run: |
-          RMD_PATH=($(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '[.]Rmd$'))
-          Rscript -e 'for (f in commandArgs(TRUE)) if (file.exists(f)) rmarkdown::render(f)' ${RMD_PATH[*]}
-
-      - name: Commit results
-        run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git commit ${RMD_PATH[*]/.Rmd/.md} -m 'Re-build Rmarkdown files' || echo "No changes to commit"
-          git push origin || echo "No changes to commit"
-```
-
 ## Build bookdown site
 
 `usethis::use_github_action("bookdown")`
@@ -759,6 +759,67 @@ jobs:
           folder: public
 ```
 
+## Shiny App Deployment
+
+`usethis::use_github_action("shiny-deploy")`
+
+This example will deploy your Shiny application to either
+[shinyapps.io](https://www.shinyapps.io/) or [RStudio
+Connect](https://www.rstudio.com/products/connect/) using the
+`rsconnect` package. The `rsconnect` package requires authorization to
+deploy an app using your account. This action does this by using your
+user name (`RSCONNECT_USER`), token (`RSCONNECT_TOKEN`), and secret
+(`RSCONNECT_SECRET`), which are securely accessed as GitHub Secrets.
+**Your token and secret are private and should be kept confidential**.
+
+This action assumes you have an `renv` lockfile in your repository that
+describes the `R` packages and versions required for your Shiny
+application.
+
+-   See here for information on how to obtain the token and secret for
+    configuring `rsconnect`:
+    <https://shiny.rstudio.com/articles/shinyapps.html>
+
+-   See here for information on how to store private tokens in a
+    repository as GitHub Secrets:
+    <https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository>
+
+``` yaml
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+
+name: shiny-deploy
+
+jobs:
+  shiny-deploy:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-renv@v2
+
+      - name: Install rsconnect
+        run: install.packages("rsconnect")
+        shell: Rscript {0}
+
+      - name: Authorize and deploy app
+        run: |
+          rsconnect::setAccountInfo(${{ secrets.RSCONNECT_USER }}, ${{ secrets.RSCONNECT_TOKEN }}, ${{ secrets.RSCONNECT_SECRET }})
+          rsconnect::deployApp()
+        shell: Rscript {0}
+```
+
 ## Docker based workflow
 
 `usethis::use_github_action("docker")`
@@ -857,67 +918,6 @@ jobs:
 
       - name: Lint root directory
         run: lintr::lint_dir()
-        shell: Rscript {0}
-```
-
-## Shiny App Deployment
-
-`usethis::use_github_action("shiny-deploy")`
-
-This example will deploy your Shiny application to either
-[shinyapps.io](https://www.shinyapps.io/) or [RStudio
-Connect](https://www.rstudio.com/products/connect/) using the
-`rsconnect` package. The `rsconnect` package requires authorization to
-deploy an app using your account. This action does this by using your
-user name (`RSCONNECT_USER`), token (`RSCONNECT_TOKEN`), and secret
-(`RSCONNECT_SECRET`), which are securely accessed as GitHub Secrets.
-**Your token and secret are private and should be kept confidential**.
-
-This action assumes you have an `renv` lockfile in your repository that
-describes the `R` packages and versions required for your Shiny
-application.
-
--   See here for information on how to obtain the token and secret for
-    configuring `rsconnect`:
-    <https://shiny.rstudio.com/articles/shinyapps.html>
-
--   See here for information on how to store private tokens in a
-    repository as GitHub Secrets:
-    <https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository>
-
-``` yaml
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
-on:
-  push:
-    branches: [main, master]
-
-name: shiny-deploy
-
-jobs:
-  shiny-deploy:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-renv@v2
-
-      - name: Install rsconnect
-        run: install.packages("rsconnect")
-        shell: Rscript {0}
-
-      - name: Authorize and deploy app
-        run: |
-          rsconnect::setAccountInfo(${{ secrets.RSCONNECT_USER }}, ${{ secrets.RSCONNECT_TOKEN }}, ${{ secrets.RSCONNECT_SECRET }})
-          rsconnect::deployApp()
         shell: Rscript {0}
 ```
 

--- a/examples/document.yaml
+++ b/examples/document.yaml
@@ -28,6 +28,7 @@ jobs:
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::roxygen2
+          needs: roxygen2
 
       - name: Document
         run: roxygen2::roxygenise()

--- a/examples/document.yaml
+++ b/examples/document.yaml
@@ -1,0 +1,42 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    paths: ["R/**"]
+  pull_request:
+    paths: ["R/**"]
+
+name: Document
+
+jobs:
+  document:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::roxygen2
+
+      - name: Document
+        run: roxygen2::roxygenise()
+        shell: Rscript {0}
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add man/\* NAMESPACE
+          git commit -m "Update documentation" || echo "No changes to commit"
+          git push origin || echo "No changes to commit"

--- a/examples/document.yaml
+++ b/examples/document.yaml
@@ -39,4 +39,5 @@ jobs:
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git add man/\* NAMESPACE
           git commit -m "Update documentation" || echo "No changes to commit"
+          git pull --ff-only || echo "No remote changes"
           git push origin || echo "No changes to commit"

--- a/examples/document.yaml
+++ b/examples/document.yaml
@@ -40,5 +40,5 @@ jobs:
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git add man/\* NAMESPACE
           git commit -m "Update documentation" || echo "No changes to commit"
-          git pull --ff-only || echo "No remote changes"
-          git push origin || echo "No changes to commit"
+          git pull --ff-only
+          git push origin

--- a/examples/style.yaml
+++ b/examples/style.yaml
@@ -28,6 +28,7 @@ jobs:
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::styler
+          needs: styler
 
       - name: Style
         run: styler::style_pkg()

--- a/examples/style.yaml
+++ b/examples/style.yaml
@@ -30,6 +30,27 @@ jobs:
           extra-packages: any::styler
           needs: styler
 
+      - name: Enable styler cache
+        run: styler::cache_activate()
+        shell: Rscript {0}
+
+      - name: Determine cache location
+        id: styler-loc
+        run: |
+          cat(
+            "##[set-output name=loc;]",
+            styler::cache_info(format = "tabular")$location,
+            "\n",
+            sep = ""
+          )
+        shell: Rscript {0}
+
+      - name: Cache styler
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.styler-loc.outputs.loc }}
+          key: ${{ runner.os }}-styler
+
       - name: Style
         run: styler::style_pkg()
         shell: Rscript {0}

--- a/examples/style.yaml
+++ b/examples/style.yaml
@@ -1,0 +1,43 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    paths: ["R/**"]
+  pull_request:
+    paths: ["R/**"]
+
+name: Style
+
+jobs:
+  style:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::styler
+
+      - name: Style
+        run: styler::style_pkg()
+        shell: Rscript {0}
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add R/\*
+          git commit -m "Style code" || echo "No changes to commit"
+          git pull --ff-only || echo "No remote changes"
+          git push origin || echo "No changes to commit"

--- a/examples/style.yaml
+++ b/examples/style.yaml
@@ -35,10 +35,10 @@ jobs:
         shell: Rscript {0}
 
       - name: Determine cache location
-        id: styler-loc
+        id: styler-location
         run: |
           cat(
-            "##[set-output name=loc;]",
+            "##[set-output name=location;]",
             styler::cache_info(format = "tabular")$location,
             "\n",
             sep = ""
@@ -48,7 +48,7 @@ jobs:
       - name: Cache styler
         uses: actions/cache@v2
         with:
-          path: ${{ steps.styler-loc.outputs.loc }}
+          path: ${{ steps.styler-location.outputs.location }}
           key: ${{ runner.os }}-styler-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-styler-

--- a/examples/style.yaml
+++ b/examples/style.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    paths: ["R/**"]
+    paths: ["R/**", "tests/**", "vignettes/**"]
   pull_request:
-    paths: ["R/**"]
+    paths: ["R/**", "tests/**", "vignettes/**"]
 
 name: Style
 
@@ -55,7 +55,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Style
-        run: styler::style_pkg()
+        run: styler::style_pkg(filetype = c(".R", ".Rmd", ".Rmarkdown", ".Rnw"))
         shell: Rscript {0}
 
       - name: Commit and push changes

--- a/examples/style.yaml
+++ b/examples/style.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    paths: ["R/**", "tests/**", "vignettes/**"]
+    paths: ["**.[rR]", "**.[rR]md", "**.[rR]markdown", "**.[rR]nw"]
   pull_request:
-    paths: ["R/**", "tests/**", "vignettes/**"]
+    paths: ["**.[rR]", "**.[rR]md", "**.[rR]markdown", "**.[rR]nw"]
 
 name: Style
 

--- a/examples/style.yaml
+++ b/examples/style.yaml
@@ -40,5 +40,5 @@ jobs:
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git add R/\*
           git commit -m "Style code" || echo "No changes to commit"
-          git pull --ff-only || echo "No remote changes"
-          git push origin || echo "No changes to commit"
+          git pull --ff-only
+          git push origin

--- a/examples/style.yaml
+++ b/examples/style.yaml
@@ -49,7 +49,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.styler-loc.outputs.loc }}
-          key: ${{ runner.os }}-styler
+          key: ${{ runner.os }}-styler-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-styler-
+            ${{ runner.os }}-
 
       - name: Style
         run: styler::style_pkg()


### PR DESCRIPTION
This PR adds two new workflows, `document` and `style`, which document a package and style the code in a package. Both workflows are triggered by changes to the `R/` directory on pushes and PRs. After changes are made, the workflows commit and then push the changes to the branch.

Workflows were tested here: https://github.com/arisp99/testactionspkg.

Closes #434.