### PR TITLE
Remove backports PPA

### DIFF
--- a/setup-r/lib/installer.js
+++ b/setup-r/lib/installer.js
@@ -228,10 +228,6 @@ function acquireRUbuntu(version) {
             throw new Error("Temp directory not set");
         }
         try {
-            // Important backports needed for CRAN packages, including libgit2
-            yield core.group('Adding ppa:cran/travis repository', () => __awaiter(this, void 0, void 0, function* () {
-                yield exec.exec("sudo DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:cran/travis");
-            }));
             yield core.group('Updating system package data', () => __awaiter(this, void 0, void 0, function* () {
                 yield exec.exec("sudo DEBIAN_FRONTEND=noninteractive apt-get update -y -qq");
             }));

--- a/setup-r/src/installer.ts
+++ b/setup-r/src/installer.ts
@@ -200,13 +200,6 @@ async function acquireRUbuntu(version: string): Promise<string> {
   }
 
   try {
-    // Important backports needed for CRAN packages, including libgit2
-    await core.group('Adding ppa:cran/travis repository', async() => {
-      await exec.exec(
-        "sudo DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:cran/travis"
-      );
-    });
-
     await core.group('Updating system package data', async() => {
       await exec.exec(
         "sudo DEBIAN_FRONTEND=noninteractive apt-get update -y -qq"


### PR DESCRIPTION
We created the `ppa:cran/travis` repository mostly for backports on ubuntu 14 and 16, which are now gone.

For Ubuntu 18 it contains only a few libs, including libgit2 and libv8. However the corresponding R packages provide static libs for these now, so the PPA is no longer needed.

I think v2 is a good moment to phase this out (a few days too late but not many people have switched yet).
