### PR TITLE
update blogdown examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ If your build fails and you are unsure of why here are some useful strategies fo
 
 ## Common questions
 
-1. Why are my builds with plots failing on macOS?
+1. *Why are my builds with plots failing on macOS?*\
+\
   You need to install XQuartz to do plotting with the default quartz device on macOS. This can be done by adding the following to your workflow.
     ```yaml
     - if: runner.os == 'macOS'
@@ -75,6 +76,7 @@ If your build fails and you are unsure of why here are some useful strategies fo
     ```
 
 1. *Why are my Windows builds failing with an error about `configure.ac` having CRLF line endings?*\
+\
   On Windows, when your repo is checked out using git the line endings are automatically changed to CRLF. R's check process specifically checks if the `configure.ac` file has these line endings, and will error if it does. To avoid this, add a `.gitattributes` file to the top level of your package with the following to configure git to always use LF line endings for this file: \
   `configure.ac text eol=lf`
   

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If your build fails and you are unsure of why here are some useful strategies fo
   
 1. *How can I customize an action to run R code?*\
 \
-The safest way is to add a `step` to your action, specifying `Rscript {0}` as the `shell` for that step. Here's an example from the [bookdown action](https://github.com/r-lib/actions/tree/v2-branch/examples#build-bookdown-site)
+The safest way is to add a `step` to your action, specifying `Rscript {0}` as the `shell` for that step. Here's an example from the [bookdown action](https://github.com/r-lib/actions/tree/v2-branch/examples#build-bookdown-site):
     ```yaml
     - name: Build site
       run: bookdown::render_book("index.Rmd", quiet = TRUE)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,15 @@ If your build fails and you are unsure of why here are some useful strategies fo
   On Windows, when your repo is checked out using git the line endings are automatically changed to CRLF. R's check process specifically checks if the `configure.ac` file has these line endings, and will error if it does. To avoid this, add a `.gitattributes` file to the top level of your package with the following to configure git to always use LF line endings for this file: \
   `configure.ac text eol=lf`
   
-
+1. *How can I customize an action to run R code?*\
+\
+The safest way is to add a `step` to your action, specifying `Rscript {0}` as the `shell` for that step. Here's an example from the [bookdown action](https://github.com/r-lib/actions/tree/v2-branch/examples#build-bookdown-site)
+    ```yaml
+    - name: Build site
+      run: bookdown::render_book("index.Rmd", quiet = TRUE)
+      shell: Rscript {0}
+   ```
+  
 ## Additional resources
 
 - [GitHub Actions for R](https://www.jimhester.com/talk/2020-rsc-github-actions/), Jim Hester's talk at rstudio::conf 2020. [Recording](https://resources.rstudio.com/rstudio-conf-2020/azure-pipelines-and-github-actions-jim-hester), [slidedeck](https://speakerdeck.com/jimhester/github-actions-for-r).

--- a/examples/README.Rmd
+++ b/examples/README.Rmd
@@ -38,7 +38,6 @@ Other workflows:
 Options and advice: 
 
 - [Forcing binaries](#forcing-binaries) - An environment variable to always use binary packages. 
-- [Managing secrets](#managing-secrets) - How to generate auth tokens and make them available to actions.
 
 ## Quickstart CI workflow
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -514,7 +514,8 @@ jobs:
           needs: website
 
       - name: Build site
-        run: Rscript -e 'pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)'
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'

--- a/examples/README.md
+++ b/examples/README.md
@@ -731,10 +731,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: source("fit_model.R")
-        shell: Rscript {0}
-
-      - run: rmarkdown::render("report.Rmd")
+      - run: |
+          source("fit_model.R")
+          rmarkdown::render("report.Rmd")
         shell: Rscript {0}
 
       - name: Upload results

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,8 +46,6 @@ Options and advice:
 
 -   [Forcing binaries](#forcing-binaries) - An environment variable to
     always use binary packages.
--   [Managing secrets](#managing-secrets) - How to generate auth tokens
-    and make them available to actions.
 
 ## Quickstart CI workflow
 
@@ -373,7 +371,8 @@ jobs:
           needs: pr-document
 
       - name: Document
-        run: Rscript -e 'roxygen2::roxygenise()'
+        run: roxygen2::roxygenise()
+        shell: Rscript {0}
 
       - name: commit
         run: |
@@ -402,10 +401,12 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
 
       - name: Install dependencies
-        run: Rscript -e 'install.packages("styler")'
+        run: install.packages("styler")
+        shell: Rscript {0}
 
       - name: Style
-        run: Rscript -e 'styler::style_pkg()'
+        run: styler::style_pkg()
+        shell: Rscript {0}
 
       - name: commit
         run: |
@@ -512,17 +513,16 @@ jobs:
           extra-packages: any::pkgdown, local::.
           needs: website
 
-      - name: Deploy package
-        if: github.event_name != 'pull_request'
-        run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'
+      - name: Build site
+        run: Rscript -e 'pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)'
 
-      - name: Build site without deploying
-        if: github.event_name == 'pull_request'
-        run: |
-          Rscript -e 'pkgdown::build_site(preview = FALSE, install = FALSE)'
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs
 ```
 
 ## Build bookdown site
@@ -576,7 +576,8 @@ jobs:
           restore-keys: bookdown-
 
       - name: Build site
-        run: Rscript -e 'bookdown::render_book("index.Rmd", quiet = TRUE)'
+        run: bookdown::render_book("index.Rmd", quiet = TRUE)
+        shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
@@ -629,12 +630,12 @@ jobs:
       - uses: r-lib/actions/setup-renv@v2
 
       - name: Install hugo
-        run: |
-          R -e 'blogdown::install_hugo()'
+        run: blogdown::install_hugo()
+        shell: Rscript {0}
 
       - name: Build site
-        run: |
-          R -e 'blogdown::build_site(TRUE)'
+        run: blogdown::build_site(TRUE)
+        shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
@@ -730,9 +731,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: Rscript fit_model.R
+      - run: source("fit_model.R")
+        shell: Rscript {0}
 
-      - run: Rscript -e 'rmarkdown::render("report.Rmd")'
+      - run: rmarkdown::render("report.Rmd")
+        shell: Rscript {0}
 
       - name: Upload results
         uses: actions/upload-artifact@main

--- a/examples/blogdown.yaml
+++ b/examples/blogdown.yaml
@@ -26,12 +26,12 @@ jobs:
       - uses: r-lib/actions/setup-renv@v2
 
       - name: Install hugo
-        run: |
-          R -e 'blogdown::install_hugo()'
+        run: blogdown::install_hugo()
+        shell: Rscript {0}
 
       - name: Build site
-        run: |
-          R -e 'blogdown::build_site(TRUE)'
+        run: blogdown::build_site(TRUE)
+        shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'

--- a/examples/bookdown.yaml
+++ b/examples/bookdown.yaml
@@ -33,7 +33,8 @@ jobs:
           restore-keys: bookdown-
 
       - name: Build site
-        run: Rscript -e 'bookdown::render_book("index.Rmd", quiet = TRUE)'
+        run: bookdown::render_book("index.Rmd", quiet = TRUE)
+        shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'

--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -11,9 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: Rscript fit_model.R
+      - run: source("fit_model.R")
+        shell: Rscript {0}
 
-      - run: Rscript -e 'rmarkdown::render("report.Rmd")'
+      - run: rmarkdown::render("report.Rmd")
+        shell: Rscript {0}
 
       - name: Upload results
         uses: actions/upload-artifact@main

--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -11,10 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: source("fit_model.R")
-        shell: Rscript {0}
-
-      - run: rmarkdown::render("report.Rmd")
+      - run: |
+          source("fit_model.R")
+          rmarkdown::render("report.Rmd")
         shell: Rscript {0}
 
       - name: Upload results

--- a/examples/pkgdown.yaml
+++ b/examples/pkgdown.yaml
@@ -31,7 +31,8 @@ jobs:
           needs: website
 
       - name: Build site
-        run: Rscript -e 'pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)'
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'

--- a/examples/pr-commands.yaml
+++ b/examples/pr-commands.yaml
@@ -30,7 +30,8 @@ jobs:
           needs: pr-document
 
       - name: Document
-        run: Rscript -e 'roxygen2::roxygenise()'
+        run: roxygen2::roxygenise()
+        shell: Rscript {0}
 
       - name: commit
         run: |
@@ -59,10 +60,12 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
 
       - name: Install dependencies
-        run: Rscript -e 'install.packages("styler")'
+        run: install.packages("styler")
+        shell: Rscript {0}
 
       - name: Style
-        run: Rscript -e 'styler::style_pkg()'
+        run: styler::style_pkg()
+        shell: Rscript {0}
 
       - name: commit
         run: |


### PR DESCRIPTION
fix #475

I just want to make sure this is the sort of thing you have in mind. I propose to update the others accordingly, then re-render `examples/README.Rmd`.

I'm also thinking to propose few words for [common questions](https://github.com/r-lib/actions#common-questions) to encourage this syntax for those who adapt these examples to their situation.