### PR TITLE
fix style command in README

### DIFF
--- a/examples/README.Rmd
+++ b/examples/README.Rmd
@@ -178,7 +178,7 @@ print_yaml("document.yaml")
 
 ## Style package
 
-`usethis::use_github_action("document")`
+`usethis::use_github_action("style")`
 
 This example styles the R code in a package, then commits and pushes the changes
 to the same branch.

--- a/examples/README.md
+++ b/examples/README.md
@@ -586,7 +586,7 @@ jobs:
 
 ## Style package
 
-`usethis::use_github_action("document")`
+`usethis::use_github_action("style")`
 
 This example styles the R code in a package, then commits and pushes the
 changes to the same branch.


### PR DESCRIPTION
I think the example command for setting up the workflow got copied over from the previous one.

In addition: I noted that the `.md` is outdated, but I did not re-render it, because I did not know if that was on purpose. cc @arisp99 