### PR TITLE
Restore rtools40 path

### DIFF
--- a/setup-r/lib/installer.js
+++ b/setup-r/lib/installer.js
@@ -437,6 +437,7 @@ function acquireRtools(version) {
             core.addPath(`C:\\rtools42\\x86_64-w64-mingw32.static.posix\\bin`);
         }
         else if (rtools40) {
+            core.addPath(`C:\\rtools40\\usr\\bin`);
             if (core.getInput("r-version").match("devel")) {
                 core.addPath(`C:\\rtools40\\ucrt64\\bin`);
                 core.exportVariable("_R_INSTALL_TIME_PATCHES_", "no");

--- a/setup-r/src/installer.ts
+++ b/setup-r/src/installer.ts
@@ -420,10 +420,10 @@ async function acquireRtools(version: string) {
     }
   }
   if (rtools42) {
-      core.addPath(`C:\\rtools42\\usr\\bin`);
-      core.addPath(`C:\\rtools42\\x86_64-w64-mingw32.static.posix\\bin`);
-
+    core.addPath(`C:\\rtools42\\usr\\bin`);
+    core.addPath(`C:\\rtools42\\x86_64-w64-mingw32.static.posix\\bin`);
   } else if (rtools40) {
+    core.addPath(`C:\\rtools40\\usr\\bin`);
     if (core.getInput("r-version").match("devel")) {
       core.addPath(`C:\\rtools40\\ucrt64\\bin`);
       core.exportVariable("_R_INSTALL_TIME_PATCHES_", "no");


### PR DESCRIPTION
On https://github.com/apache/arrow/pull/12436 I was trying to update our workflows to use `v2` but ran into a problem where `pacman` could not be found (we use the pacman bundled with rtools as part of building C++ dependencies for the R package). 

Doing some digging, it looks like https://github.com/r-lib/actions/commit/18ab426b87dc230e2eb2d3efda516f30399f70b2 inadvertently removed the line that adds rtools to the path for rtools40. 

To confirm, I set up a simple workflow [here](https://github.com/nealrichardson/sandbox/blob/pacman/.github/workflows/test.yml) that looks for pacman. It [confirms](https://github.com/nealrichardson/sandbox/actions/runs/1853450170) it is working on `master` but not `v2`, and that this PR fixes the issue. 