### PR TITLE
Add upload-results parameter

### DIFF
--- a/check-r-package/README.md
+++ b/check-r-package/README.md
@@ -18,6 +18,8 @@ Inputs available:
   parameter of `rcmdcheck`. It must be an R expression in single quotes.
 - upload-artifacts - default `false`. Whether to upload all testthat
   snapshots as an artifact.
+- upload-results - default `false`. Whether to upload check results for
+  successful runs too.
 - working-directory - default `"."`. If the R package to check is not in
   the root directory of your repository.
 

--- a/check-r-package/action.yaml
+++ b/check-r-package/action.yaml
@@ -20,7 +20,10 @@ inputs:
   upload-snapshots:
     description: 'Whether to upload all testthat snapshots as an artifact.'
     default: false
-    
+  upload-results:
+    description: 'Whether to upload check results for successful runs too.'
+    default: false
+
 runs:
   using: "composite"
   steps:
@@ -46,7 +49,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
 
     - name: Upload check results
-      if: failure()
+      if: failure() || inputs.upload-results != 'false'
       uses: actions/upload-artifact@main
       with:
         name: ${{ runner.os }}-r${{ matrix.config.r }}-results


### PR DESCRIPTION
Sometimes it can be useful to inspect output from examples and tests, even if there was no failure.