### PR TITLE
Remove `.github/pkg.lock` when done using the lock file

### DIFF
--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -79,6 +79,8 @@ runs:
           } else {
             sessionInfo()
           }
+          ## Clean up lock file
+          unlink(".github/pkg.lock")
           cat("::endgroup::\n")
         shell: Rscript {0}
         working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
When looking at the git status, this lock file is untracked and always added.

If everything has been installed and the session info has been displayed, I propose that the file be cleaned up when it is done being used.