### PR TITLE
Fix unhandled promise rejections

### DIFF
--- a/setup-pandoc/lib/setup-pandoc.js
+++ b/setup-pandoc/lib/setup-pandoc.js
@@ -60,6 +60,7 @@ if (!tempDirectory) {
     tempDirectory = path.join(baseLocation, "actions", "temp");
 }
 function run() {
+    var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         try {
             let pandocVersion = core.getInput("pandoc-version");
@@ -67,7 +68,7 @@ function run() {
             yield getPandoc(pandocVersion);
         }
         catch (error) {
-            core.setFailed(error.message);
+            core.setFailed((_b = (_a = error === null || error === void 0 ? void 0 : error.message) !== null && _a !== void 0 ? _a : error) !== null && _b !== void 0 ? _b : "Unknown error");
         }
     });
 }
@@ -84,6 +85,7 @@ function getPandoc(version) {
 }
 exports.getPandoc = getPandoc;
 function installPandocMac(version) {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         const fileName = util.format("pandoc-%s-macOS.pkg", version);
         const downloadUrl = util.format("https://github.com/jgm/pandoc/releases/download/%s/%s", version, fileName);
@@ -92,7 +94,7 @@ function installPandocMac(version) {
             downloadPath = yield tc.downloadTool(downloadUrl);
         }
         catch (error) {
-            throw `Failed to download Pandoc ${version}: ${error}`;
+            throw new Error(`Failed to download Pandoc ${version}: ${(_a = error === null || error === void 0 ? void 0 : error.message) !== null && _a !== void 0 ? _a : error}`);
         }
         yield io.mv(downloadPath, path.join(tempDirectory, fileName));
         exec.exec("sudo installer", [
@@ -106,6 +108,7 @@ function installPandocMac(version) {
     });
 }
 function installPandocWindows(version) {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         const fileName = util.format("pandoc-%s-windows-x86_64.zip", version);
         const downloadUrl = util.format("https://github.com/jgm/pandoc/releases/download/%s/%s", version, fileName);
@@ -114,7 +117,7 @@ function installPandocWindows(version) {
             downloadPath = yield tc.downloadTool(downloadUrl);
         }
         catch (error) {
-            throw `Failed to download Pandoc ${version}: ${error}`;
+            throw new Error(`Failed to download Pandoc ${version}: ${(_a = error === null || error === void 0 ? void 0 : error.message) !== null && _a !== void 0 ? _a : error}`);
         }
         //
         // Extract
@@ -140,6 +143,7 @@ function pandocSubdir(version) {
     return util.format("pandoc-%s-windows-x86_64", version);
 }
 function installPandocLinux(version) {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         const fileName = util.format("pandoc-%s-1-amd64.deb", version);
         const downloadUrl = util.format("https://github.com/jgm/pandoc/releases/download/%s/%s", version, fileName);
@@ -149,7 +153,7 @@ function installPandocLinux(version) {
             downloadPath = yield tc.downloadTool(downloadUrl);
         }
         catch (error) {
-            throw `Failed to download Pandoc ${version}: ${error}`;
+            throw new Error(`Failed to download Pandoc ${version}: ${error}`);
         }
         yield io.mv(downloadPath, path.join(tempDirectory, fileName));
         try {
@@ -162,8 +166,7 @@ function installPandocLinux(version) {
             ]);
         }
         catch (error) {
-            core.debug(error);
-            throw `Failed to install pandoc: ${error}`;
+            throw new Error(`Failed to install pandoc: ${(_a = error === null || error === void 0 ? void 0 : error.message) !== null && _a !== void 0 ? _a : error}`);
         }
         console.log("::endgroup::");
     });

--- a/setup-pandoc/lib/setup-pandoc.js
+++ b/setup-pandoc/lib/setup-pandoc.js
@@ -154,7 +154,7 @@ function installPandocLinux(version) {
         yield io.mv(downloadPath, path.join(tempDirectory, fileName));
         try {
             console.log("::group::Install gdebi-core");
-            yield exec.exec("sudo apt-get", ["install", "-yqq", "gdebi-core"]);
+            yield exec.exec("sudo apt-get", ["install", "-y", "gdebi-core"]);
             console.log("::group::Install pandoc");
             yield exec.exec("sudo gdebi", [
                 "--non-interactive",

--- a/setup-pandoc/lib/setup-pandoc.js
+++ b/setup-pandoc/lib/setup-pandoc.js
@@ -1,4 +1,27 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -8,14 +31,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.getPandoc = void 0;
 let tempDirectory = process.env["RUNNER_TEMP"] || "";
 const core = __importStar(require("@actions/core"));
 const exec = __importStar(require("@actions/exec"));
@@ -55,24 +72,22 @@ function run() {
     });
 }
 function getPandoc(version) {
-    return __awaiter(this, void 0, void 0, function* () {
-        if (IS_WINDOWS) {
-            installPandocWindows(version);
-        }
-        else if (IS_MAC) {
-            installPandocMac(version);
-        }
-        else {
-            installPandocLinux(version);
-        }
-    });
+    if (IS_WINDOWS) {
+        return installPandocWindows(version);
+    }
+    else if (IS_MAC) {
+        return installPandocMac(version);
+    }
+    else {
+        return installPandocLinux(version);
+    }
 }
 exports.getPandoc = getPandoc;
 function installPandocMac(version) {
     return __awaiter(this, void 0, void 0, function* () {
         const fileName = util.format("pandoc-%s-macOS.pkg", version);
         const downloadUrl = util.format("https://github.com/jgm/pandoc/releases/download/%s/%s", version, fileName);
-        let downloadPath = null;
+        let downloadPath;
         try {
             downloadPath = yield tc.downloadTool(downloadUrl);
         }
@@ -94,7 +109,7 @@ function installPandocWindows(version) {
     return __awaiter(this, void 0, void 0, function* () {
         const fileName = util.format("pandoc-%s-windows-x86_64.zip", version);
         const downloadUrl = util.format("https://github.com/jgm/pandoc/releases/download/%s/%s", version, fileName);
-        let downloadPath = null;
+        let downloadPath;
         try {
             downloadPath = yield tc.downloadTool(downloadUrl);
         }
@@ -116,10 +131,10 @@ function installPandocWindows(version) {
     });
 }
 function pandocSubdir(version) {
-    if (compare_versions_1.compare(version, "2.9.2", ">=")) {
+    if ((0, compare_versions_1.compare)(version, "2.9.2", ">=")) {
         return util.format("pandoc-%s", version);
     }
-    if (compare_versions_1.compare(version, "2.9.1", "=")) {
+    if ((0, compare_versions_1.compare)(version, "2.9.1", "=")) {
         return "";
     }
     return util.format("pandoc-%s-windows-x86_64", version);
@@ -128,7 +143,7 @@ function installPandocLinux(version) {
     return __awaiter(this, void 0, void 0, function* () {
         const fileName = util.format("pandoc-%s-1-amd64.deb", version);
         const downloadUrl = util.format("https://github.com/jgm/pandoc/releases/download/%s/%s", version, fileName);
-        let downloadPath = null;
+        let downloadPath;
         try {
             console.log("::group::Download pandoc");
             downloadPath = yield tc.downloadTool(downloadUrl);
@@ -139,7 +154,7 @@ function installPandocLinux(version) {
         yield io.mv(downloadPath, path.join(tempDirectory, fileName));
         try {
             console.log("::group::Install gdebi-core");
-            yield exec.exec("sudo apt-get", ["install", "-y", "gdebi-core"]);
+            yield exec.exec("sudo apt-get", ["install", "-yqq", "gdebi-core"]);
             console.log("::group::Install pandoc");
             yield exec.exec("sudo gdebi", [
                 "--non-interactive",

--- a/setup-pandoc/lib/setup-pandoc.js
+++ b/setup-pandoc/lib/setup-pandoc.js
@@ -1,11 +1,7 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -18,7 +14,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -134,10 +130,10 @@ function installPandocWindows(version) {
     });
 }
 function pandocSubdir(version) {
-    if ((0, compare_versions_1.compare)(version, "2.9.2", ">=")) {
+    if (compare_versions_1.compare(version, "2.9.2", ">=")) {
         return util.format("pandoc-%s", version);
     }
-    if ((0, compare_versions_1.compare)(version, "2.9.1", "=")) {
+    if (compare_versions_1.compare(version, "2.9.1", "=")) {
         return "";
     }
     return util.format("pandoc-%s-windows-x86_64", version);

--- a/setup-pandoc/src/setup-pandoc.ts
+++ b/setup-pandoc/src/setup-pandoc.ts
@@ -139,7 +139,7 @@ async function installPandocLinux(version: string): Promise<void> {
 
   try {
     console.log("::group::Install gdebi-core");
-    await exec.exec("sudo apt-get", ["install", "-y", "gdebi-core"]);
+    await exec.exec("sudo apt-get", ["install", "-yqq", "gdebi-core"]);
     console.log("::group::Install pandoc");
     await exec.exec("sudo gdebi", [
       "--non-interactive",

--- a/setup-pandoc/src/setup-pandoc.ts
+++ b/setup-pandoc/src/setup-pandoc.ts
@@ -32,7 +32,7 @@ async function run() {
     let pandocVersion = core.getInput("pandoc-version");
     core.debug(`got pandoc-version ${pandocVersion}`);
     await getPandoc(pandocVersion);
-  } catch (error: any) {
+  } catch (error) {
     core.setFailed(error?.message ?? error ?? "Unknown error");
   }
 }
@@ -58,7 +58,7 @@ async function installPandocMac(version: string): Promise<void> {
   let downloadPath: string;
   try {
     downloadPath = await tc.downloadTool(downloadUrl);
-  } catch (error: any) {
+  } catch (error) {
     throw new Error(`Failed to download Pandoc ${version}: ${error?.message ?? error}`);
   }
 
@@ -85,7 +85,7 @@ async function installPandocWindows(version: string): Promise<void> {
   let downloadPath: string;
   try {
     downloadPath = await tc.downloadTool(downloadUrl);
-  } catch (error: any) {
+  } catch (error) {
     throw new Error(`Failed to download Pandoc ${version}: ${error?.message ?? error}`);
   }
 
@@ -145,7 +145,7 @@ async function installPandocLinux(version: string): Promise<void> {
       "--non-interactive",
       path.join(tempDirectory, fileName)
     ]);
-  } catch (error: any) {
+  } catch (error) {
     throw new Error(`Failed to install pandoc: ${error?.message ?? error}`);
   }
   console.log("::endgroup::");

--- a/setup-pandoc/src/setup-pandoc.ts
+++ b/setup-pandoc/src/setup-pandoc.ts
@@ -139,7 +139,7 @@ async function installPandocLinux(version: string): Promise<void> {
 
   try {
     console.log("::group::Install gdebi-core");
-    await exec.exec("sudo apt-get", ["install", "-yqq", "gdebi-core"]);
+    await exec.exec("sudo apt-get", ["install", "-y", "gdebi-core"]);
     console.log("::group::Install pandoc");
     await exec.exec("sudo gdebi", [
       "--non-interactive",

--- a/setup-pandoc/src/setup-pandoc.ts
+++ b/setup-pandoc/src/setup-pandoc.ts
@@ -54,8 +54,8 @@ async function installPandocMac(version: string): Promise<void> {
     version,
     fileName
   );
-  let downloadPath: string | null = null;
 
+  let downloadPath: string;
   try {
     downloadPath = await tc.downloadTool(downloadUrl);
   } catch (error) {
@@ -81,8 +81,8 @@ async function installPandocWindows(version: string): Promise<void> {
     version,
     fileName
   );
-  let downloadPath: string | null = null;
 
+  let downloadPath: string;
   try {
     downloadPath = await tc.downloadTool(downloadUrl);
   } catch (error) {
@@ -126,8 +126,8 @@ async function installPandocLinux(version: string): Promise<void> {
     version,
     fileName
   );
-  let downloadPath: string | null = null;
 
+  let downloadPath: string;
   try {
     console.log("::group::Download pandoc");
     downloadPath = await tc.downloadTool(downloadUrl);

--- a/setup-pandoc/src/setup-pandoc.ts
+++ b/setup-pandoc/src/setup-pandoc.ts
@@ -37,17 +37,17 @@ async function run() {
   }
 }
 
-export async function getPandoc(version: string) {
+export function getPandoc(version: string): Promise<void> {
   if (IS_WINDOWS) {
-    installPandocWindows(version);
+    return installPandocWindows(version);
   } else if (IS_MAC) {
-    installPandocMac(version);
+    return installPandocMac(version);
   } else {
-    installPandocLinux(version);
+    return installPandocLinux(version);
   }
 }
 
-async function installPandocMac(version: string) {
+async function installPandocMac(version: string): Promise<void> {
   const fileName = util.format("pandoc-%s-macOS.pkg", version);
   const downloadUrl = util.format(
     "https://github.com/jgm/pandoc/releases/download/%s/%s",
@@ -74,7 +74,7 @@ async function installPandocMac(version: string) {
   ]);
 }
 
-async function installPandocWindows(version: string) {
+async function installPandocWindows(version: string): Promise<void> {
   const fileName = util.format("pandoc-%s-windows-x86_64.zip", version);
   const downloadUrl = util.format(
     "https://github.com/jgm/pandoc/releases/download/%s/%s",
@@ -119,7 +119,7 @@ function pandocSubdir(version: string) {
   return util.format("pandoc-%s-windows-x86_64", version);
 }
 
-async function installPandocLinux(version: string) {
+async function installPandocLinux(version: string): Promise<void> {
   const fileName = util.format("pandoc-%s-1-amd64.deb", version);
   const downloadUrl = util.format(
     "https://github.com/jgm/pandoc/releases/download/%s/%s",

--- a/setup-pandoc/src/setup-pandoc.ts
+++ b/setup-pandoc/src/setup-pandoc.ts
@@ -32,8 +32,8 @@ async function run() {
     let pandocVersion = core.getInput("pandoc-version");
     core.debug(`got pandoc-version ${pandocVersion}`);
     await getPandoc(pandocVersion);
-  } catch (error) {
-    core.setFailed(error.message);
+  } catch (error: any) {
+    core.setFailed(error?.message ?? error ?? "Unknown error");
   }
 }
 
@@ -58,8 +58,8 @@ async function installPandocMac(version: string): Promise<void> {
   let downloadPath: string;
   try {
     downloadPath = await tc.downloadTool(downloadUrl);
-  } catch (error) {
-    throw `Failed to download Pandoc ${version}: ${error}`;
+  } catch (error: any) {
+    throw new Error(`Failed to download Pandoc ${version}: ${error?.message ?? error}`);
   }
 
   await io.mv(downloadPath, path.join(tempDirectory, fileName));
@@ -85,8 +85,8 @@ async function installPandocWindows(version: string): Promise<void> {
   let downloadPath: string;
   try {
     downloadPath = await tc.downloadTool(downloadUrl);
-  } catch (error) {
-    throw `Failed to download Pandoc ${version}: ${error}`;
+  } catch (error: any) {
+    throw new Error(`Failed to download Pandoc ${version}: ${error?.message ?? error}`);
   }
 
   //
@@ -132,7 +132,7 @@ async function installPandocLinux(version: string): Promise<void> {
     console.log("::group::Download pandoc");
     downloadPath = await tc.downloadTool(downloadUrl);
   } catch (error) {
-    throw `Failed to download Pandoc ${version}: ${error}`;
+    throw new Error(`Failed to download Pandoc ${version}: ${error}`);
   }
 
   await io.mv(downloadPath, path.join(tempDirectory, fileName));
@@ -145,10 +145,8 @@ async function installPandocLinux(version: string): Promise<void> {
       "--non-interactive",
       path.join(tempDirectory, fileName)
     ]);
-  } catch (error) {
-    core.debug(error);
-
-    throw `Failed to install pandoc: ${error}`;
+  } catch (error: any) {
+    throw new Error(`Failed to install pandoc: ${error?.message ?? error}`);
   }
   console.log("::endgroup::");
 }


### PR DESCRIPTION
While forking and refactoring this action, I discovered some issues. This is a backport to upstream of these fixes.

In case the installation fails, the exception is not propagated to the try-catch in `run()`, but dropped instead.
We resolve this by returning their promises.

Resolves #515