### PR TITLE
Added additionally example showing with inputs

### DIFF
--- a/check-r-package/README.md
+++ b/check-r-package/README.md
@@ -34,6 +34,19 @@ steps:
 - uses: r-lib/actions/check-r-package@v2
 ```
 
+With specified input:
+```yaml
+steps:
+- uses: actions/checkout@v2
+- uses: r-lib/actions/setup-r@v2
+- uses: r-lib/actions/setup-r-dependencies@v2
+  with:
+    extra-packages: rcmdcheck
+- uses: r-lib/actions/check-r-package@v2
+  with:
+    error_on: error
+```
+
 # License
 
 The scripts and documentation in this project are released under the [MIT License](LICENSE)

--- a/check-r-package/README.md
+++ b/check-r-package/README.md
@@ -44,7 +44,7 @@ steps:
     extra-packages: rcmdcheck
 - uses: r-lib/actions/check-r-package@v2
   with:
-    error_on: error
+    error-on: error
 ```
 
 # License


### PR DESCRIPTION
Added one additional example showing a use-case with inputs in the `.yaml` example.

Issue: #517 
