### PR TITLE
install local package in lint workflow, fixes #557

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: ./setup-r-dependencies
         with:
-          extra-packages: any::lintr
+          extra-packages: any::lintr, local::.
           needs: lint
 
       - name: Lint

--- a/examples/lint.yaml
+++ b/examples/lint.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::lintr
+          extra-packages: any::lintr, local::.
           needs: lint
 
       - name: Lint


### PR DESCRIPTION
This ought to fix #557, see example in {opencage}.

I am not entirely sure https://github.com/r-lib/actions/blob/v2-branch/examples/lint-project.yaml needs adjusting, but I think not?

I made the same change to the workflow for this repo, as well.