### PR TITLE
Fix using exposed `check-dir` when uploading artifacts

### DIFF
--- a/check-r-package/action.yaml
+++ b/check-r-package/action.yaml
@@ -28,13 +28,15 @@ runs:
   using: "composite"
   steps:
     - name: Check
+      id: rcmdcheck    
       env:
         _R_CHECK_CRAN_INCOMING_: false
       run: |
         ## --------------------------------------------------------------------
         options(crayon.enabled = TRUE)
         if (Sys.getenv("_R_CHECK_FORCE_SUGGESTS_", "") == "") Sys.setenv("_R_CHECK_FORCE_SUGGESTS_" = "false")
-        rcmdcheck::rcmdcheck(args = (${{ inputs.args }}), build_args = (${{ inputs.build_args }}), error_on = (${{ inputs.error-on }}), check_dir = (${{ inputs.check-dir }}))
+        check_results <- rcmdcheck::rcmdcheck(args = (${{ inputs.args }}), build_args = (${{ inputs.build_args }}), error_on = (${{ inputs.error-on }}), check_dir = (${{ inputs.check-dir }}))
+        cat("##[set-output name=check-dir-path;]", dirname(check_results$checkdir), "\n", sep = "")
       shell: Rscript {0}
       working-directory: ${{ inputs.working-directory }}
 
@@ -53,12 +55,12 @@ runs:
       uses: actions/upload-artifact@main
       with:
         name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-        path: ${{ inputs.working-directory }}/check
+        path: ${{ steps.rcmdcheck.outputs.check-dir-path }}
 
     - name: Upload snapshots
       if: inputs.upload-snapshots != 'false'
       uses: actions/upload-artifact@main
       with:
         name: ${{ runner.os }}-r${{ matrix.config.r }}-testthat-snapshots
-        path: ${{ inputs.working-directory }}/check/**/tests*/testthat/_snaps
+        path: ${{ steps.rcmdcheck.outputs.check-dir-path }}/**/tests*/testthat/_snaps
         if-no-files-found: ignore


### PR DESCRIPTION
A hard-coded `check` was still used when uploading artifacts.

Given the R-expression-nature of `inputs.check-dir`, I relied on the resolved path included by `rcmdcheck::rcmdcheck` in the returned object (not sure if there is a better alternative to this).

Tested in a workflow with
```yml
      - uses: r-lib/actions/check-r-package@v2-branch
        with:
          check-dir: '"non-default-dir"'
          upload-results: true
          upload-snapshots: true
```

https://github.com/riccardoporreca/actions/runs/6460856210?check_suite_focus=true#step:6:149
```
Warning: No files were found with the provided path: ./check. No artifacts will be uploaded.
```
https://github.com/riccardoporreca/actions/runs/6460856210?check_suite_focus=true#step:6:163
```
No files were found with the provided path: ./check/**/tests*/testthat/_snaps. No artifacts will be uploaded.
```

Artifacts are correctly uploaded when using the branch with the proposed fix:
https://github.com/riccardoporreca/actions/actions/runs/2334950233#artifacts