### PR TITLE
Fix unquoted secrets of `shiny-deploy.yaml` and suggest to provide app name, account, and server 

### DIFF
--- a/examples/shiny-deploy.yaml
+++ b/examples/shiny-deploy.yaml
@@ -27,7 +27,12 @@ jobs:
         shell: Rscript {0}
 
       - name: Authorize and deploy app
+        env: 
+          # Provide your account name and app name to be deployed below
+          ACCOUNT: your-account-name
+          APPNAME: your-app-name
+          SERVER: shinyapps.io # server to deploy
         run: |
-          rsconnect::setAccountInfo(${{ secrets.RSCONNECT_USER }}, ${{ secrets.RSCONNECT_TOKEN }}, ${{ secrets.RSCONNECT_SECRET }})
-          rsconnect::deployApp()
+          rsconnect::setAccountInfo("${{ secrets.RSCONNECT_USER }}", "${{ secrets.RSCONNECT_TOKEN }}", "${{ secrets.RSCONNECT_SECRET }}")
+          rsconnect::deployApp(appName = "${{ env.APPNAME }}", account = "${{ env.ACCOUNT }}", server = "${{ env.SERVER }}")
         shell: Rscript {0}

--- a/examples/shiny-deploy.yaml
+++ b/examples/shiny-deploy.yaml
@@ -28,9 +28,9 @@ jobs:
 
       - name: Authorize and deploy app
         env: 
-          # Provide your account name and app name to be deployed below
-          ACCOUNT: your-account-name
+          # Provide your app name, account name, and server to be deployed below
           APPNAME: your-app-name
+          ACCOUNT: your-account-name
           SERVER: shinyapps.io # server to deploy
         run: |
           rsconnect::setAccountInfo("${{ secrets.RSCONNECT_USER }}", "${{ secrets.RSCONNECT_TOKEN }}", "${{ secrets.RSCONNECT_SECRET }}")


### PR DESCRIPTION
Hi, I would like to fix & improve GHA for deploy Shiny App 

## Must Fix 

I've added double quote surrounding the `${{ secrets.RSCONNECT_* }}`, since the value of secrets is unquoted, so it must be "quoted" to be R character vector. 

(See this [fail run](https://github.com/Lightbridge-KS/quarto-shiny-faithful/runs/7564223815?check_suite_focus=true) for the problem)

## Improve

I think that it might be better to explicitly provide app name, account name, and server. 

For example, if user already deployed offline (e.g., blue button in RStudio), rsconnect will need an account name (see [failed run](https://github.com/Lightbridge-KS/quarto-shiny-faithful/runs/7565032334?check_suite_focus=true)).

So, I've extracted `APPNAME`, `ACCOUNT`, and `SERVER` environment variables for those parameters.

## Example

Here is the working example: [shiny-deploy.yml](https://github.com/Lightbridge-KS/quarto-shiny-faithful/blob/main/.github/workflows/shiny-deploy.yaml)
- [App](https://kittipos.shinyapps.io/faithful/)
- [Repository](https://github.com/Lightbridge-KS/quarto-shiny-faithful)

(the `Authorize and deploy app` part is about the same as my proposed change)

Thankyou