### PR TITLE
Fix resolving the exposed `check-dir` for the artifact upload

### DIFF
--- a/check-r-package/action.yaml
+++ b/check-r-package/action.yaml
@@ -35,8 +35,8 @@ runs:
         ## --------------------------------------------------------------------
         options(crayon.enabled = TRUE)
         if (Sys.getenv("_R_CHECK_FORCE_SUGGESTS_", "") == "") Sys.setenv("_R_CHECK_FORCE_SUGGESTS_" = "false")
+        cat("##[set-output name=check-dir-path;]", (${{ inputs.check-dir }}), "\n", sep = "")
         check_results <- rcmdcheck::rcmdcheck(args = (${{ inputs.args }}), build_args = (${{ inputs.build_args }}), error_on = (${{ inputs.error-on }}), check_dir = (${{ inputs.check-dir }}))
-        cat("##[set-output name=check-dir-path;]", dirname(check_results$checkdir), "\n", sep = "")
       shell: Rscript {0}
       working-directory: ${{ inputs.working-directory }}
 


### PR DESCRIPTION
* Given the R-expression-nature of `inputs.check-dir`, we still rely on a step output defined from within R but just uses the expression.
* We need to define the output before running the checks to fix #593 (introduced by #560) in case of check failures.

See https://github.com/r-lib/actions/issues/593#issuecomment-1205732302 and run https://github.com/riccardoporreca/actions/runs/7679961505?check_suite_focus=true#step:6:174 for the reproduced issue
> Error: Input required and not supplied: path

See the same case fixed when using proposed fix from the branch in https://github.com/riccardoporreca/actions/runs/7680406669?check_suite_focus=true#step:6:164
> Run actions/upload-artifact@main
>  with:
>    name: Linux-rrelease-results
>    path: non-default-dir
>    if-no-files-found: warn