### PR TITLE
Deploy via GHA workflow instead of gh-pages branch

### DIFF
--- a/examples/pkgdown.yaml
+++ b/examples/pkgdown.yaml
@@ -37,10 +37,24 @@ jobs:
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
 
-      - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          clean: false
-          branch: gh-pages
-          folder: docs
+          path: ./docs
+
+  # Deployment job
+  deploy:
+    if: github.event_name != 'pull_request'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: pkgdown
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
I understand this needs to be discussed but I figured a PR with some code would be clearer than an issue.

This PR uses GitHub pages new deploy mechanism, as presented in [this recent blog post](https://github.blog/2022-08-10-github-pages-now-uses-actions-by-default/) and in [GitHub's changelog](https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/).

Pros:
- no extra `gh-pages` branch
- no unofficial actions (where `JamesIves/github-pages-deploy-action` is currently used)
- use of what is apparently the new recommended way to deploy
- website is automatically uploaded as an artifact, which opens up options to deal with PR vs push. For example, in this PR, I set it up so artifact is always uploaded but only deployed on pushes. This means that anybody can easily inspect the website without having to render it locally. Additionally, netlify previews will probably be easier to handle. The first job is the same for both PR and pushes and you then have two jobs/deploy paths.

Cons:
- the website source code is no longer visible on a branch and history is not saved.

Example of the change proposed here in the wild: https://github.com/Bisaloo/fundiversity/blob/main/.github/workflows/pkgdown.yaml

If you like this change, I can implement it in all the other workflows where it would be relevant. I just did pkgdown here as an example.