### PR TITLE
Use ubuntu-latest

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -28,13 +28,12 @@ jobs:
           # Use 3.6 to trigger usage of RTools35
           - {os: windows-latest, r: '3.6'}
 
-          # Use older ubuntu to maximise backward compatibility
-          - {os: ubuntu-20.04,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-20.04,   r: 'release'}
-          - {os: ubuntu-20.04,   r: 'oldrel-1'}
-          - {os: ubuntu-20.04,   r: 'oldrel-2'}
-          - {os: ubuntu-20.04,   r: 'oldrel-3'}
-          - {os: ubuntu-20.04,   r: 'oldrel-4'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,   r: 'oldrel-2'}
+          - {os: ubuntu-latest,   r: 'oldrel-3'}
+          - {os: ubuntu-latest,   r: 'oldrel-4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/r-devel-test.yaml
+++ b/.github/workflows/r-devel-test.yaml
@@ -24,7 +24,7 @@ jobs:
         config:
           - {os: macOS-latest,   r: 'devel'}
           - {os: windows-latest, r: 'devel'}
-          - {os: ubuntu-20.04,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/setup-r-test.yaml
+++ b/.github/workflows/setup-r-test.yaml
@@ -19,8 +19,8 @@ jobs:
           - {os: windows-latest, r: 'release'}
           - {os: windows-latest, r: 'next'}
 
-          - {os: ubuntu-20.04,   r: 'release'}
-          - {os: ubuntu-20.04,   r: 'next'}
+          - {os: ubuntu-latest,  r: 'release'}
+          - {os: ubuntu-latest,  r: 'next'}
 
     steps:
       - uses: actions/checkout@v2

--- a/examples/README.md
+++ b/examples/README.md
@@ -215,12 +215,12 @@ jobs:
           - {os: windows-latest, r: '3.6'}
 
           # Use older ubuntu to maximise backward compatibility
-          - {os: ubuntu-20.04,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-20.04,   r: 'release'}
-          - {os: ubuntu-20.04,   r: 'oldrel-1'}
-          - {os: ubuntu-20.04,   r: 'oldrel-2'}
-          - {os: ubuntu-20.04,   r: 'oldrel-3'}
-          - {os: ubuntu-20.04,   r: 'oldrel-4'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,   r: 'oldrel-2'}
+          - {os: ubuntu-latest,   r: 'oldrel-3'}
+          - {os: ubuntu-latest,   r: 'oldrel-4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/check-full.yaml
+++ b/examples/check-full.yaml
@@ -28,13 +28,12 @@ jobs:
           # Use 3.6 to trigger usage of RTools35
           - {os: windows-latest, r: '3.6'}
 
-          # Use older ubuntu to maximise backward compatibility
-          - {os: ubuntu-20.04,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-20.04,   r: 'release'}
-          - {os: ubuntu-20.04,   r: 'oldrel-1'}
-          - {os: ubuntu-20.04,   r: 'oldrel-2'}
-          - {os: ubuntu-20.04,   r: 'oldrel-3'}
-          - {os: ubuntu-20.04,   r: 'oldrel-4'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,   r: 'oldrel-2'}
+          - {os: ubuntu-latest,   r: 'oldrel-3'}
+          - {os: ubuntu-latest,   r: 'oldrel-4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/setup-r/README.Rmd
+++ b/setup-r/README.Rmd
@@ -55,7 +55,7 @@ Matrix Testing:
 ```yaml
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         R: [ '3.5.3', '3.6.1' ]

--- a/setup-r/README.md
+++ b/setup-r/README.md
@@ -81,7 +81,7 @@ Matrix Testing:
 ``` yaml
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         R: [ '3.5.3', '3.6.1' ]


### PR DESCRIPTION
I think we're better off defaulting to `ubuntu-latest` so we don't need to regularly update most workflows. Packages that do need to confirm compatibility with older ubuntu can add their own additional checks.

Closes #606.