### PR TITLE
Remove redundant setting env var in lint changed workflow

### DIFF
--- a/examples/lint-changed-files.yml
+++ b/examples/lint-changed-files.yml
@@ -34,7 +34,6 @@ jobs:
 
       - name: Extract and lint files changed by this PR
         run: |
-          Sys.setenv("LINTR_ERROR_ON_LINT" = TRUE)
           files <- gh::gh("GET https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
           changed_files <- purrr::map_chr(files, "filename")
           all_files <- list.files(recursive = TRUE)


### PR DESCRIPTION
Given that it is already now set here:

https://github.com/r-lib/actions/blob/8560979e97443c93f5dfdc762e7ce893a9358d0e/examples/lint-changed-files.yml#L44-L45