### PR TITLE
Simplify `R-CMD-check-hard` workflow

### DIFF
--- a/examples/check-no-suggests.yaml
+++ b/examples/check-no-suggests.yaml
@@ -15,16 +15,8 @@ on:
 name: R-CMD-check-hard
 
 jobs:
-  R-CMD-check:
-    runs-on: ${{ matrix.config.os }}
-
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {os: ubuntu-latest,   r: 'release'}
+  R-CMD-check-hard:
+    runs-on: ubuntu-latest
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -37,8 +29,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: ${{ matrix.config.r }}
-          http-user-agent: ${{ matrix.config.http-user-agent }}
+          r-version: "release"
+          http-user-agent: "release"
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2


### PR DESCRIPTION
IINM, the matrix strategy is not needed here, so the workflow can be simplified.