### PR TITLE
Update Package Manager URLs to use CRAN repo and posit DNS

### DIFF
--- a/setup-r/lib/installer.js
+++ b/setup-r/lib/installer.js
@@ -520,7 +520,7 @@ function setupRLibrary() {
         let rspm = process.env["RSPM"] ? `'${process.env["RSPM"]}'` : "NULL";
         if (rspm === "NULL" && core.getInput("use-public-rspm") === "true") {
             if (IS_WINDOWS) {
-                rspm = "'https://packagemanager.rstudio.com/all/latest'";
+                rspm = "'https://packagemanager.posit.co/cran/latest'";
             }
             if (IS_LINUX) {
                 let codename = "";
@@ -536,7 +536,7 @@ function setupRLibrary() {
                     throw `Failed to query the linux version: ${error}`;
                 }
                 codename = codename.trim();
-                rspm = `'https://packagemanager.rstudio.com/all/__linux__/${codename}/latest'`;
+                rspm = `'https://packagemanager.posit.co/cran/__linux__/${codename}/latest'`;
             }
         }
         if (rspm !== "NULL") {

--- a/setup-r/src/installer.ts
+++ b/setup-r/src/installer.ts
@@ -505,7 +505,7 @@ async function setupRLibrary() {
 
   if (rspm === "NULL" && core.getInput("use-public-rspm") === "true") {
     if (IS_WINDOWS) {
-      rspm = "'https://packagemanager.rstudio.com/all/latest'";
+      rspm = "'https://packagemanager.posit.co/cran/latest'";
     }
     if (IS_LINUX) {
       let codename = "";
@@ -522,7 +522,7 @@ async function setupRLibrary() {
       }
       codename = codename.trim();
 
-      rspm = `'https://packagemanager.rstudio.com/all/__linux__/${codename}/latest'`;
+      rspm = `'https://packagemanager.posit.co/cran/__linux__/${codename}/latest'`;
     }
   }
 


### PR DESCRIPTION
The Package Manager team is planning on deprecating the `all` repository. This will still work but will be hidden for new users.