### PR TITLE
Fix indentations issues in example for R CMD check

### DIFF
--- a/check-r-package/README.md
+++ b/check-r-package/README.md
@@ -48,10 +48,10 @@ steps:
     extra-packages: any::rcmdcheck
     needs: check
 - uses: r-lib/actions/check-r-package@v2
-    with:
-      args: 'c("--no-manual", "--as-cran")'
-      error-on: '"error"'
-      check-dir: '"check"'
+  with:
+    args: 'c("--no-manual", "--as-cran")'
+    error-on: '"error"'
+    check-dir: '"check"'
 ```
 
 ## Quoting R expressions


### PR DESCRIPTION
The current indentation for one of the R CMD check's examples is not correct. This PR intends to fix it.