### PR TITLE
add roxygen2 dependency to styler workflow

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -647,7 +647,7 @@ jobs:
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::styler
+          extra-packages: any::styler, any::roxygen2
           needs: styler
 
       - name: Enable styler cache
@@ -658,7 +658,7 @@ jobs:
         id: styler-location
         run: |
           cat(
-            "location=", 
+            "location=",
             styler::cache_info(format = "tabular")$location,
             "\n",
             file = Sys.getenv("GITHUB_OUTPUT"),

--- a/examples/style.yaml
+++ b/examples/style.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::styler
+          extra-packages: any::styler, any::roxygen2
           needs: styler
 
       - name: Enable styler cache
@@ -38,7 +38,7 @@ jobs:
         id: styler-location
         run: |
           cat(
-            "location=", 
+            "location=",
             styler::cache_info(format = "tabular")$location,
             "\n",
             file = Sys.getenv("GITHUB_OUTPUT"),


### PR DESCRIPTION
[I get ](https://github.com/ropensci/opencage/actions/runs/3920242071/jobs/6701746218#step:8:57)

> When processing R/foo.R: To style roxygen code examples, you need to have the package `{roxygen2}` installed. To exclude them from styling, set `include_roxygen_examples = FALSE`.

warnings, when using the [styler workflow](https://github.com/r-lib/actions/blob/v2-branch/examples/style.yaml), so I think it would be good to add roxygen2 as a dependency.