### PR TITLE
fix: commit all changed files by document workflow

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -569,8 +569,6 @@ branch.
 on:
   push:
     paths: ["R/**"]
-  pull_request:
-    paths: ["R/**"]
 
 name: Document
 
@@ -604,7 +602,7 @@ jobs:
         run: |
           git config --local user.name "$GITHUB_ACTOR"
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git add man/\* NAMESPACE
+          git add man/\* NAMESPACE DESCRIPTION
           git commit -m "Update documentation" || echo "No changes to commit"
           git pull --ff-only
           git push origin

--- a/examples/document.yaml
+++ b/examples/document.yaml
@@ -36,7 +36,7 @@ jobs:
         run: |
           git config --local user.name "$GITHUB_ACTOR"
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git add man/\* NAMESPACE
+          git add man/\* NAMESPACE DESCRIPTION
           git commit -m "Update documentation" || echo "No changes to commit"
           git pull --ff-only
           git push origin


### PR DESCRIPTION
Similar to #693 there are files missing in the https://github.com/r-lib/actions/blob/v2-branch/examples/document.yaml workflow. I.e. not all files which are affected by `roxygen2::roxygenise()` both as input and output are covered by the workflow.

One file that comes to mind is DESCRIPTION ([`Collate:`](https://roxygen2.r-lib.org/articles/roxygen2.html) and `RoxygenNote:` fields), which this PR adds to `git add`. 

I am not entirely sure which other files are affected, but I suspect @gaborcsardi to know. 😄 

I guess at least [`src/*.cpp`](https://roxygen2.r-lib.org/articles/roxygen2.html#rcpp) should be watched for changes and `R/RcppExports.R` be `git add`ed as well? Anything else?