### PR TITLE
`setup-r` gets `r-version` from `renv.lock` 

### DIFF
--- a/setup-r/README.Rmd
+++ b/setup-r/README.Rmd
@@ -47,7 +47,8 @@ steps:
 - uses: actions/checkout@v3
 - uses: r-lib/actions/setup-r@v2
   with:
-    r-version: '3.5.3' # The R version to download (if necessary) and use.
+    r-version: '3.5.3' # The R version to download (if necessary) and use. 
+    # Use "renv" to retrieve R version recorded in renv.lock file.
 - run: Rscript -e 'print("hello")'
 ```
 

--- a/setup-r/README.md
+++ b/setup-r/README.md
@@ -8,62 +8,63 @@ community](https://img.shields.io/badge/community-github--actions-blue?style=soc
 
 This action sets up an R environment for use in actions by:
 
--   Downloading and caching a version of R by version and adding to PATH
--   Registering [problem
-    matchers](https://github.com/r-lib/actions/tree/v2/setup-r/.github)
-    for error output
--   Setting the following environment variables
-    -   `NOT_CRAN=true`
-    -   `TZ=UTC`
-    -   `R_LIBS_USER=tempdir/Library`
-    -   `_R_CHECK_SYSTEM_CLOCK_=FALSE`
--   Removing the `-fopenmp` flags from Makeconf on macOS, which are not
-    supported with Apple’s default Command Line Tools compilers.
--   Appending ‘on GitHub Actions’ to the default HTTP user agent. This
-    is useful to distinguish GitHub Actions package requests from other
-    sources.
--   Supplying the installed R version as a `installed-r-version` output.
+- Downloading and caching a version of R by version and adding to PATH
+- Registering [problem
+  matchers](https://github.com/r-lib/actions/tree/v2/setup-r/.github)
+  for error output
+- Setting the following environment variables
+  - `NOT_CRAN=true`
+  - `TZ=UTC`
+  - `R_LIBS_USER=tempdir/Library`
+  - `_R_CHECK_SYSTEM_CLOCK_=FALSE`
+- Removing the `-fopenmp` flags from Makeconf on macOS, which are not
+  supported with Apple’s default Command Line Tools compilers.
+- Appending ‘on GitHub Actions’ to the default HTTP user agent. This is
+  useful to distinguish GitHub Actions package requests from other
+  sources.
+- Supplying the installed R version as a `installed-r-version` output.
 
 ## Inputs
 
--   **r-version** (`'release'`) - Version range or exact version of an R
-    version to use. “devel” is the current development version, and
-    “next” is the next version of R, either R-patched, or R-alpha,
-    R-beta, R-rc or R-prerelease.
--   **rtools-version** (`''`) - Exact version of Rtools to use. Default
-    uses latest suitable rtools for the given version of R. Set it to
-    “42” for Rtools42.
--   **Ncpus** (`'1'`) - Value to set the R option `Ncpus` to.
--   **remove-openmp-macos** (`true`) - If true, remove `-fopenmp` from
-    the default compilation flags, e.g. `SHLIB_OPENMP_CFLAGS`, as the
-    macOS Command Line Tools do not support OpenMP.
--   **http-user-agent** (`'default'`) - If `"default"` or `""`, sets the
-    HTTPUserAgent option to e.g. for R 3.6.3 running on macOS Catalina,
-    `"R/3.6.3 R (3.6.3 x86_64-apple-darwin17.0 x86_64 darwin17.0) on GitHub Actions"`.
-    If `"release"` sets the user agent to the default user agent for the
-    current R release. Otherwise uses whatever value is passed to
-    `http-user-agent`.
--   **install-r** (`true`) - If “true” download and install R during the
-    setup. If “false” use the existing installation in the GitHub Action
-    image. Note that if it is “false”, you probably need to run
-    `sudo apt-get update` yourself.
--   **windows-path-include-rtools** (`true`) - Whether to add Rtools to
-    the PATH, on Windows.
--   **windows-path-include-mingw** (`true`) - If “true” put the 64 bit
-    mingw directory from Rtools on the PATH for Windows builds. This
-    argument is now defunct on Rtools40 and later, which never add the
-    mingw directory to the path.
--   **update-rtools** (`false`) - Update rtools40 compilers and
-    libraries to the latest builds.
--   **use-public-rspm** (`false`) - Use the public version of Posit
-    package manager available at <https://packagemanager.posit.co/>
-    to serve binaries for Linux and Windows.
--   **extra-repositories** (`''`) - One or more extra CRAN-like
-    repositories to include in the `repos` global option
+- **r-version** (`'release'`) - Version range or exact version of an R
+  version to use. “devel” is the current development version, and “next”
+  is the next version of R, either R-patched, or R-alpha, R-beta, R-rc
+  or R-prerelease. Use “renv” to retrieve R version recorded in
+  renv.lock file.
+- **rtools-version** (`''`) - Exact version of Rtools to use. Default
+  uses latest suitable rtools for the given version of R. Set it to “42”
+  for Rtools42.
+- **Ncpus** (`'1'`) - Value to set the R option `Ncpus` to.
+- **remove-openmp-macos** (`true`) - If true, remove `-fopenmp` from the
+  default compilation flags, e.g. `SHLIB_OPENMP_CFLAGS`, as the macOS
+  Command Line Tools do not support OpenMP.
+- **http-user-agent** (`'default'`) - If `"default"` or `""`, sets the
+  HTTPUserAgent option to e.g. for R 3.6.3 running on macOS Catalina,
+  `"R/3.6.3 R (3.6.3 x86_64-apple-darwin17.0 x86_64 darwin17.0) on GitHub Actions"`.
+  If `"release"` sets the user agent to the default user agent for the
+  current R release. Otherwise uses whatever value is passed to
+  `http-user-agent`.
+- **install-r** (`true`) - If “true” download and install R during the
+  setup. If “false” use the existing installation in the GitHub Action
+  image. Note that if it is “false”, you probably need to run
+  `sudo apt-get update` yourself.
+- **windows-path-include-rtools** (`true`) - Whether to add Rtools to
+  the PATH.
+- **windows-path-include-mingw** (`true`) - If “true” put the 64 bit
+  mingw directory from Rtools on the PATH for Windows builds. This
+  argument is now defunct on Rtools40 and later, which never add the
+  mingw directory to the path.
+- **update-rtools** (`false`) - Update rtools40 compilers and libraries
+  to the latest builds.
+- **use-public-rspm** (`false`) - Use the public version of Posit
+  package manager available at <https://packagemanager.posit.co/> to
+  serve binaries for Linux and Windows.
+- **extra-repositories** (`''`) - One or more extra CRAN-like
+  repositories to include in the `repos` global option
 
 ## Outputs
 
--   **installed-r-version** - The full R version installed by the action
+- **installed-r-version** - The full R version installed by the action
 
 ## Usage
 
@@ -74,7 +75,8 @@ steps:
 - uses: actions/checkout@v3
 - uses: r-lib/actions/setup-r@v2
   with:
-    r-version: '3.5.3' # The R version to download (if necessary) and use.
+    r-version: '3.5.3' # The R version to download (if necessary) and use. 
+    # Use "renv" to retrieve R version recorded in renv.lock file.
 - run: Rscript -e 'print("hello")'
 ```
 

--- a/setup-r/action.yml
+++ b/setup-r/action.yml
@@ -5,7 +5,8 @@ inputs:
   r-version:
     description: 'Version range or exact version of an R version to use. "devel" is
     the current development version, and "next" is the next version of R, either
-    R-patched, or R-alpha, R-beta, R-rc or R-prerelease.'
+    R-patched, or R-alpha, R-beta, R-rc or R-prerelease. Use "renv" to retrieve R 
+    version recorded in renv.lock file.'
     default: 'release'
   rtools-version:
     description: 'Exact version of Rtools to use. Default uses latest suitable

--- a/setup-r/lib/setup-r.js
+++ b/setup-r/lib/setup-r.js
@@ -35,12 +35,28 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
 const installer_1 = require("./installer");
 const path = __importStar(require("path"));
+const fs = __importStar(require("fs"));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             core.debug(`started action`);
-            let version = core.getInput("r-version");
-            core.debug(`got version ${version}`);
+            var version;
+            version = core.getInput("r-version");
+            if (version === "renv") {
+                let renv_lock_path = "./renv.lock";
+                if (fs.existsSync(renv_lock_path)) {
+                    let renv_lock = fs.readFileSync(renv_lock_path).toString();
+                    version = JSON.parse(renv_lock).R.Version;
+                    core.debug(`got version ${version} from renv.lock`);
+                }
+                else {
+                    core.setFailed("./renv.lock does not exist.");
+                }
+            }
+            else {
+                version = version;
+                core.debug(`got version ${version} from input`);
+            }
             yield (0, installer_1.getR)(version);
             const matchersPath = path.join(__dirname, "..", ".github");
             console.log(`##[add-matcher]${path.join(matchersPath, "rcmdcheck.json")}`);

--- a/setup-r/src/setup-r.ts
+++ b/setup-r/src/setup-r.ts
@@ -1,12 +1,29 @@
 import * as core from "@actions/core";
 import { getR } from "./installer";
 import * as path from "path";
+import * as fs from "fs";
+
 
 async function run() {
   try {
     core.debug(`started action`);
-    let version = core.getInput("r-version");
-    core.debug(`got version ${version}`);
+   
+    var version: string
+    version = core.getInput("r-version")
+
+    if (version === "renv") {
+      let renv_lock_path = "./renv.lock";
+      if (fs.existsSync(renv_lock_path)) {
+        let renv_lock = fs.readFileSync(renv_lock_path).toString();
+        version = JSON.parse(renv_lock).R.Version;
+        core.debug(`got version ${version} from renv.lock`);
+      } else {
+        core.setFailed("./renv.lock does not exist.");
+      }
+    } else {
+      version = version
+      core.debug(`got version ${version} from input`);
+    }
 
     await getR(version);
 

--- a/setup-r/src/setup-r.ts
+++ b/setup-r/src/setup-r.ts
@@ -3,7 +3,6 @@ import { getR } from "./installer";
 import * as path from "path";
 import * as fs from "fs";
 
-
 async function run() {
   try {
     core.debug(`started action`);


### PR DESCRIPTION
- If user provides `renv` for `r-version` in `setup-r`, look for `./renv.lock`.
  - if found, parse and use R version recorded within
  - if not, throw error
  
#700 