### PR TITLE
Use $default-branch macro

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -6,9 +6,9 @@
 # usethis::use_github_action("check-standard") will install it.
 on:
   push:
-    branches: [main, master, v2-branch]
+    branches: [$default-branch, v2-branch]
   pull_request:
-    branches: [main, master, v2-branch]
+    branches: [$default-branch, v2-branch]
 
 name: R-CMD-check
 

--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master, v2-branch]
+    branches: [$default-branch, v2-branch]
   pull_request:
-    branches: [main, master, v2-branch]
+    branches: [$default-branch, v2-branch]
 
 name: R-CMD-check
 

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master, v2-branch]
+    branches: [$default-branch, v2-branch]
   pull_request:
-    branches: [main, master, v2-branch]
+    branches: [$default-branch, v2-branch]
 
 name: R-CMD-check
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master, v2-branch]
+    branches: [$default-branch, v2-branch]
   pull_request:
-    branches: [main, master, v2-branch]
+    branches: [$default-branch, v2-branch]
 
 name: lint
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master, v2-branch]
+    branches: [$default-branch, v2-branch]
   pull_request:
-    branches: [main, master, v2-branch]
+    branches: [$default-branch, v2-branch]
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/setup-tinytex.yaml
+++ b/.github/workflows/setup-tinytex.yaml
@@ -1,8 +1,8 @@
 on:
   push:
-    branches: [main, master, v2-branch]
+    branches: [$default-branch, v2-branch]
   pull_request:
-    branches: [main, master, v2-branch]
+    branches: [$default-branch, v2-branch]
   workflow_dispatch:
     
 name: "setup-tinytex test"

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master, v2-branch]
+    branches: [$default-branch, v2-branch]
   pull_request:
-    branches: [main, master, v2-branch]
+    branches: [$default-branch, v2-branch]
 
 name: test-coverage
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all : $(WORKFLOWS)
 
 $(WORKFLOWS) : .github/workflows/%.yaml: examples/%.yaml
 	perl -pe 's{r-lib/actions/([\w-]+)\@v2}{./$$1}g' $^ | \
-	perl -pe 's{main, master}{main, master, v2-branch}g' > $@
+	perl -pe 's{\\$default-branch}{\\$default-branch, v2-branch}g' > $@
 
 .PHONY: clean
 clean:

--- a/examples/README.md
+++ b/examples/README.md
@@ -71,9 +71,9 @@ probably what you want to use.
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
 
 name: R-CMD-check
 
@@ -118,9 +118,9 @@ CRAN or Bioconductor this is likely the workflow you want to use.
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
 
 name: R-CMD-check
 
@@ -192,9 +192,9 @@ CI workflow.
 # usethis::use_github_action("check-standard") will install it.
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
 
 name: R-CMD-check
 
@@ -261,9 +261,9 @@ the test coverage of your package and upload the result to
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
 
 name: test-coverage
 
@@ -321,9 +321,9 @@ lint your package and return the results as build annotations.
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
 
 name: lint
 
@@ -511,9 +511,9 @@ API](https://docs.github.com/en/rest/reference/actions/#create-a-workflow-dispat
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
   release:
     types: [published]
   workflow_dispatch:
@@ -710,9 +710,9 @@ additional information.
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
   workflow_dispatch:
 
 name: bookdown
@@ -774,9 +774,9 @@ additional information.
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
   workflow_dispatch:
 
 name: blogdown
@@ -846,7 +846,7 @@ application.
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
 
 name: shiny-deploy
 
@@ -957,9 +957,9 @@ lint your project and return the results as annotations.
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
 
 name: lint-project
 

--- a/examples/blogdown.yaml
+++ b/examples/blogdown.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
   workflow_dispatch:
 
 name: blogdown

--- a/examples/bookdown.yaml
+++ b/examples/bookdown.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
   workflow_dispatch:
 
 name: bookdown

--- a/examples/check-full.yaml
+++ b/examples/check-full.yaml
@@ -6,9 +6,9 @@
 # usethis::use_github_action("check-standard") will install it.
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
 
 name: R-CMD-check
 

--- a/examples/check-no-suggests.yaml
+++ b/examples/check-no-suggests.yaml
@@ -8,9 +8,9 @@
 # dependency.
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
 
 name: R-CMD-check-hard
 

--- a/examples/check-release.yaml
+++ b/examples/check-release.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
 
 name: R-CMD-check
 

--- a/examples/check-standard.yaml
+++ b/examples/check-standard.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
 
 name: R-CMD-check
 

--- a/examples/html-5-check.yaml
+++ b/examples/html-5-check.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
 
 name: HTML5 check
 

--- a/examples/lint-changed-files.yaml
+++ b/examples/lint-changed-files.yaml
@@ -2,7 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
 
 name: lint-changed-files
 

--- a/examples/lint-project.yaml
+++ b/examples/lint-project.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
 
 name: lint-project
 

--- a/examples/lint.yaml
+++ b/examples/lint.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
 
 name: lint
 

--- a/examples/pkgdown.yaml
+++ b/examples/pkgdown.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
   release:
     types: [published]
   workflow_dispatch:

--- a/examples/shiny-deploy.yaml
+++ b/examples/shiny-deploy.yaml
@@ -2,7 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
 
 name: shiny-deploy
 

--- a/examples/test-coverage.yaml
+++ b/examples/test-coverage.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [$default-branch]
   pull_request:
-    branches: [main, master]
+    branches: [$default-branch]
 
 name: test-coverage
 


### PR DESCRIPTION
Just happened to know there's a convenient macro to specify the default branch. [The official Actions](https://github.com/actions/starter-workflows) also use this.

The official announcement: https://github.blog/changelog/2020-07-22-github-actions-better-support-for-alternative-default-branch-names/