### PR TITLE
handle tinytex 2023 change about windows directory

### DIFF
--- a/setup-tinytex/lib/setup-tinytex.js
+++ b/setup-tinytex/lib/setup-tinytex.js
@@ -150,7 +150,12 @@ function installTinyTeXWindows() {
         catch (error) {
             throw `Failed to install TinyTeX: ${error}`;
         }
-        core.addPath(path.join(process.env["APPDATA"] || "C:\\", "TinyTeX", "bin", "win32"));
+        const binDir = "win32";
+        let winBin = path.join(process.env["APPDATA"] || "C:\\", "TinyTeX", "bin");
+        winBin = fs.existsSync(path.join(winBin, binDir)) ?
+            path.join(winBin, binDir) :
+            path.join(winBin, "windows");
+        core.addPath(winBin);
     });
 }
 run();

--- a/setup-tinytex/src/setup-tinytex.ts
+++ b/setup-tinytex/src/setup-tinytex.ts
@@ -120,9 +120,16 @@ async function installTinyTeXWindows() {
     throw `Failed to install TinyTeX: ${error}`;
   }
 
-  core.addPath(
-    path.join(process.env["APPDATA"] || "C:\\", "TinyTeX", "bin", "win32")
-  );
+  const binDir = "win32"
+
+  let winBin = path.join(process.env["APPDATA"] || "C:\\", "TinyTeX", "bin")
+
+  winBin = fs.existsSync(path.join(winBin, binDir)) ?
+    path.join(winBin, binDir) :
+    path.join(winBin, "windows")
+
+  core.addPath(winBin);
+
 }
 
 run();


### PR DESCRIPTION
This is a PR following new TeX Live 2023 release that modified the windows directory from `win32` to `windows`

This follows work in https://github.com/rstudio/tinytex-releases/issues/36 to adapt our scripts, our bundles and Quarto. Updating the action is the last thing I believe. 

I tested this worflow  in https://github.com/cderv/test-actions/actions/runs/4492118666/jobs/7901556408 - Everything installed correctly and is added to PATH by `core.addPath()` 

I ran `npm run build` locally which produce the js file. If there is anything else to do, please tell me. 