### PR TITLE
Give `GITHUB_TOKEN` permission to write during pkgdown build-and-deploy

### DIFF
--- a/examples/pkgdown.yaml
+++ b/examples/pkgdown.yaml
@@ -19,6 +19,8 @@ jobs:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
In February, GitHub changed the default permissions for `GITHUB_TOKEN` to read-only:

https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/

This doesn't impact existing organizations or repositories, which is why we (who work mostly in r-lib and tidyverse orgs) don't immediately feel the effects. But regular users, creating new repos, will, by default, have a read-only `GITHUB_TOKEN` in GHA.

And this means our standard example pkgdown build-and-deploy workflow fails in that scenario.

Closes https://github.com/r-lib/usethis/issues/1813
Closes https://github.com/r-lib/pkgdown/issues/2280 (according to @maelle https://github.com/r-lib/usethis/issues/1813#issuecomment-1495699625)
Closes https://github.com/hadley/r-pkgs/issues/977

The most narrowly scoped change is to give `GITHUB_TOKEN` permission to write content in the workflow config, which is what this PR does. Notably this is also what is now shown in the docs for https://github.com/JamesIves/github-pages-deploy-action. More useful docs and examples are here: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token

Here's a small example. First attempt to deploy a pkgdown site for this new package fails in the deploy step:

https://github.com/jennybc/teengecko/actions/runs/4767788243

Here's the most clear part of the log:

```
Force-pushing changes...
/usr/bin/git push --force ***github.com/jennybc/teengecko.git github-pages-deploy-action/l4p78rrgz:gh-pages
remote: Permission to jennybc/teengecko.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/jennybc/teengecko.git/': The requested URL returned error: 403
```

With the change in this PR, next attempt succeeds:

https://github.com/jennybc/teengecko/actions/runs/4767894848


