### PR TITLE
Clean pkgdown website on releases

### DIFF
--- a/examples/pkgdown.yaml
+++ b/examples/pkgdown.yaml
@@ -43,6 +43,6 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
-          clean: false
+          clean: ${{ github.event_name == 'release' }}
           branch: gh-pages
           folder: docs


### PR DESCRIPTION
This avoid keeping obsolete vignettes that have been deleted from the main branch. I believe it's safe and a good trade-off to clean on releases.

Related: https://github.com/r-lib/actions/issues/484

I have added the following comment in my internal workflow and can copy it here if you believe that'd be helpful:

    # We clean on releases because we want to remove old vignettes, 
    # figures, etc. that have been deleted from the `main` branch.
    # But we clean ONLY on releases because we want to be able to keep
    # both the 'stable' and 'dev' websites.
    # Also discussed in https://github.com/r-lib/actions/issues/484