### PR TITLE
change string type to template literal

### DIFF
--- a/setup-r/lib/installer.js
+++ b/setup-r/lib/installer.js
@@ -140,7 +140,7 @@ function acquireR(version) {
                     ok = true;
                 }
                 catch (error) {
-                    core.warning("Failed to download qpdf or ghostscript: ${error}");
+                    core.warning(`Failed to download qpdf or ghostscript: ${error}`);
                     yield new Promise(f => setTimeout(f, 10000));
                     tries_left = tries_left - 1;
                 }

--- a/setup-r/src/installer.ts
+++ b/setup-r/src/installer.ts
@@ -119,7 +119,7 @@ async function acquireR(version: IRVersion) {
         await acquireQpdfWindows(noqpdf);
         ok = true;
       } catch (error) {
-        core.warning("Failed to download qpdf or ghostscript: ${error}");
+        core.warning(`Failed to download qpdf or ghostscript: ${error}`);
           await new Promise(f => setTimeout(f, 10000));
           tries_left = tries_left - 1;
       }


### PR DESCRIPTION
When using the library, I noticed that errors are not rendered correctly and the warning just contains a plain ${error}.

e.g.

```
Run r-lib/actions/setup-r@v2.6.3
C:\action-runner\_work\_temp\R-4.3.0-win.exe /VERYSILENT /SUPPRESSMSGBOXES /DIR=C:\R
Downloading https://github.com/r-hub/rtools42/releases/download/latest/rtools42.exe...
C:\action-runner\_work\_temp\rtools42.exe /VERYSILENT /SUPPRESSMSGBOXES
Warning: Failed to download qpdf or ghostscript: ${error}
Warning: Failed to download qpdf or ghostscript: ${error}
Warning: Failed to download qpdf or ghostscript: ${error}
Warning: Failed to download qpdf or ghostscript: ${error}
Warning: Failed to download qpdf or ghostscript: ${error}
Warning: Failed to download qpdf or ghostscript: ${error}
Warning: Failed to download qpdf or ghostscript: ${error}
Warning: Failed to download qpdf or ghostscript: ${error}
Warning: Failed to download qpdf or ghostscript: ${error}
Warning: Failed to download qpdf or ghostscript: ${error}
Error: Failed to get R release: Failed to get qpdf and ghostscript in 10 tries :(
```