### PR TITLE
Disable sandbox in renv

### DIFF
--- a/setup-renv/README.md
+++ b/setup-renv/README.md
@@ -18,6 +18,7 @@ must be an R expression. Note that you often need to quote it, see details
 below.
 - `cache-version` - default `1`. If you need to invalidate the existing cache pass any other number and a new cache will be used.
 - `bypass-cache` - default `false`. To skip the use of the GitHub cache completely (such as for local testing), set to `true`.
+- `sandbox` - default `true`. To disable sandboxing within renv, set to `false`.
 
 Example:
 

--- a/setup-renv/action.yaml
+++ b/setup-renv/action.yaml
@@ -11,6 +11,9 @@ inputs:
   bypass-cache:
     description: 'Whether attempts to cache should be completely skipped (for non GitHub testing). Set to `true` to skip.'
     default: "false"
+  sandbox:
+    description: 'Whether renv should use sandbox (see documentation). Set to `false` to disable.'
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -23,6 +26,7 @@ runs:
         run: |
           if (!requireNamespace("renv", quietly=TRUE)) install.packages("renv")
           renv::activate(profile = ${{ inputs.profile }})
+          options(renv.config.sandbox.enabled = as.logical(${{ inputs.sandbox }}))
         shell: Rscript {0}
 
       - name: Get R and OS version


### PR DESCRIPTION
When I use `{renv}`, I often work with a lot of packages and I get the following warning in Github Action logs:

```r
Warning message:
renv took longer than expected (20 seconds) to activate the sandbox.

The sandbox can be disabled by setting:

    RENV_CONFIG_SANDBOX_ENABLED = FALSE

within an appropriate start-up .Renviron file.
```

This message is not much helpful, because the `.Renviron` file can't be uploaded to Github as it may contain sensitive data. This is why I propose a new parameter - `sandbox` - which sets the environmental variable after `{renv}` is activated. 

I hope I am merging this into the correct branch - if anything, feel free to let me know :)