### PR TITLE
Only set _R_CHECK_CRAN_INCOMING_ if not set externally

### DIFF
--- a/check-r-package/action.yaml
+++ b/check-r-package/action.yaml
@@ -28,14 +28,13 @@ runs:
   using: "composite"
   steps:
     - name: Check
-      id: rcmdcheck    
-      env:
-        _R_CHECK_CRAN_INCOMING_: false
+      id: rcmdcheck
       run: |
         ## --------------------------------------------------------------------
         options(crayon.enabled = TRUE)
         cat("LOGNAME=", Sys.info()[["user"]], "\n", sep = "", file = Sys.getenv("GITHUB_ENV"), append = TRUE)
         if (Sys.getenv("_R_CHECK_FORCE_SUGGESTS_", "") == "") Sys.setenv("_R_CHECK_FORCE_SUGGESTS_" = "false")
+        if (Sys.getenv("_R_CHECK_CRAN_INCOMING_", "") == "") Sys.setenv("_R_CHECK_CRAN_INCOMING_" = "false")
         cat("check-dir-path=", file.path(getwd(), (${{ inputs.check-dir }})), "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
         check_results <- rcmdcheck::rcmdcheck(args = (${{ inputs.args }}), build_args = (${{ inputs.build_args }}), error_on = (${{ inputs.error-on }}), check_dir = (${{ inputs.check-dir }}))
       shell: Rscript {0}


### PR DESCRIPTION
I want to use incoming checks on CI/CD before sending to CRAN.