### PR TITLE
Give GITHUB_TOKEN permission to write during style action "Commit and push changes" step

### DIFF
--- a/examples/style.yaml
+++ b/examples/style.yaml
@@ -9,6 +9,8 @@ name: Style
 jobs:
   style:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
As mentioned in https://github.com/r-lib/actions/issues/774, the style action fails on the "Commit and push changes" for repositories in which the `GITHUB_TOKEN` has default permissions (these defaults were updated in Feb 2023), as they don't allow changes to be pushed back to the branch.  This PR gives the `GITHUB_TOKEN` permission to write to the repo.  A similar change was made in #719.