### PR TITLE
add ' which prevents bash from treating the \ path separators as escapes

### DIFF
--- a/examples/test-coverage.yaml
+++ b/examples/test-coverage.yaml
@@ -39,7 +39,7 @@ jobs:
         if: always()
         run: |
           ## --------------------------------------------------------------------
-          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
         shell: bash
 
       - name: Upload test results


### PR DESCRIPTION
fixes #781 