### PR TITLE
Remove homebrew R from the PATH

### DIFF
--- a/setup-r/lib/installer.js
+++ b/setup-r/lib/installer.js
@@ -387,16 +387,23 @@ function acquireRMacOS(version) {
             core.debug(`${error}`);
             throw `Failed to install R: ${error}`;
         }
+        // Remove homebrew R from the PATH
+        try {
+            yield exec.exec("brew", ["unlink", "r"]);
+        }
+        catch (error) {
+            core.debug(`${error}`);
+        }
         // Older R versions on newer macOS cannot create a symlink to R and
         // Rscript, we'll need to do it manually.
         try {
             yield exec.exec("sudo ln", [
-                "-sf",
+                "-sfv",
                 "/Library/Frameworks/R.framework/Resources/bin/R",
                 "/usr/local/bin/R"
             ]);
             yield exec.exec("sudo ln", [
-                "-sf",
+                "-sfv",
                 "/Library/Frameworks/R.framework/Resources/bin/Rscript",
                 "/usr/local/bin/Rscript"
             ]);

--- a/setup-r/src/installer.ts
+++ b/setup-r/src/installer.ts
@@ -370,16 +370,23 @@ async function acquireRMacOS(version: IRVersion): Promise<string> {
     throw `Failed to install R: ${error}`;
   }
 
+  // Remove homebrew R from the PATH
+  try {
+    await exec.exec("brew", ["unlink", "r"]);
+  } catch (error) {
+    core.debug(`${error}`);
+  }
+
   // Older R versions on newer macOS cannot create a symlink to R and
   // Rscript, we'll need to do it manually.
   try {
     await exec.exec("sudo ln", [
-      "-sf",
+      "-sfv",
       "/Library/Frameworks/R.framework/Resources/bin/R",
       "/usr/local/bin/R"
     ]);
     await exec.exec("sudo ln", [
-      "-sf",
+      "-sfv",
       "/Library/Frameworks/R.framework/Resources/bin/Rscript",
       "/usr/local/bin/Rscript"
     ]);


### PR DESCRIPTION
This fixes the build on arm64, because `/opt/homebrew/bin` becomes earlier on the PATH than /usr/local/lib