### PR TITLE
Use .Library.site for pak::lockfile_create() lib parameter in setup-r-dependencies action

### DIFF
--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -112,6 +112,7 @@ runs:
           pak::lockfile_create(
             c(deps, extra_deps),
             lockfile = ".github/pkg.lock",
+            lib = .Library.site,
             upgrade = (${{ inputs.upgrade }}),
             dependencies = c(needs, (${{ inputs.dependencies }}))
           )


### PR DESCRIPTION
See issue: https://github.com/r-lib/actions/issues/814