### PR TITLE
Update OS in `check-release` action docs

### DIFF
--- a/examples/README.Rmd
+++ b/examples/README.Rmd
@@ -46,7 +46,7 @@ Options and advice:
 
 `usethis::use_github_action("check-release")`
 
-This workflow installs latest release R version on macOS
+This workflow installs latest release R version on linux
 and runs R CMD check via the [rcmdcheck](https://github.com/r-lib/rcmdcheck)
 package. If this is the first time you have used CI for a project this is
 probably what you want to use.

--- a/examples/README.md
+++ b/examples/README.md
@@ -62,7 +62,7 @@ Options and advice:
 
 `usethis::use_github_action("check-release")`
 
-This workflow installs latest release R version on macOS and runs R CMD
+This workflow installs latest release R version on linux and runs R CMD
 check via the [rcmdcheck](https://github.com/r-lib/rcmdcheck) package.
 If this is the first time you have used CI for a project this is
 probably what you want to use.


### PR DESCRIPTION
`check-release` runs on Ubuntu:
```yaml
jobs:
  R-CMD-check:
    runs-on: ubuntu-latest
```
but the docs state it runs on `macOS`. 

This updates the docs.
