### PR TITLE
[setup-r-dependencies] Allow skipping pak install step

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,12 @@
   unchanged, on all R versions. To avoid using a P3M snapshot on R 3.6.x,
   set the `RSPM_PIN_3_6` environment variable to `false`.
 
+* `[setup-r-dependencies]` now accepts `pak-version: none` to skip pak
+  installation. pak should be already installed on the system in this
+  case, otherwise the dependencies resolution and installation will fail.
+  You probably also need to set the `R_LIB_FOR_PAK` env var to the library
+  where it is installed.
+
 # `v2.9.0` (2024-05-09)
 
 * The `test-coverage.yaml` example workflow now handles global Codecov

--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -134,6 +134,7 @@ runs:
           path: |
             ${{ env.R_LIBS_USER }}/*
             !${{ env.R_LIBS_USER }}/pak
+            !${{ env.R_LIBS_USER }}/_cache
           key: ${{ format('{0}-{1}-{2}-{3}', steps.install.outputs.os-version, steps.install.outputs.r-version, inputs.cache-version, hashFiles(format('{0}/.github/pkg.lock', inputs.working-directory ))) }}
           restore-keys: ${{ format('{0}-{1}-{2}-', steps.install.outputs.os-version, steps.install.outputs.r-version, inputs.cache-version) }}
           # Used to save package installation on troublesome Actions

--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -64,7 +64,7 @@ runs:
         shell: Rscript {0}
 
       - name: Install pak (Windows)
-        if: runner.os == 'Windows'
+        if: ${{ runner.os == 'Windows' && inputs.pak-version != 'none' }}
         run: |
           # Install pak
           cat("::group::Install pak\n")
@@ -81,7 +81,7 @@ runs:
         shell: Rscript {0}
 
       - name: Install pak (Unix)
-        if: runner.os != 'Windows'
+        if: ${{ runner.os != 'Windows' && inputs.pak-version != 'none' }}
         run: |
           # Install pak
           echo "::group::Install pak"


### PR DESCRIPTION
Specify: pak-version: none

This is mainly to run on containers that already have a native pak installed. Especially because we might not have an appropriate binary build for them.