### PR TITLE
[setup-r-dependencies]: run quarto-actions/setup in temp dir

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -56,7 +56,6 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
-          install-quarto: false
 
       - uses: ./check-r-package
         with:

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -56,6 +56,7 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
+          install-quarto: false
 
       - uses: ./check-r-package
         with:

--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -240,7 +240,6 @@ runs:
         uses: quarto-dev/quarto-actions/setup@v2
         with:
           version: ${{ inputs.quarto-version }}
-        working-directory: ${{ runner.temp }}
 
       - name: Session info
         run: |

--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -240,6 +240,7 @@ runs:
         uses: quarto-dev/quarto-actions/setup@v2
         with:
           version: ${{ inputs.quarto-version }}
+        working-directory: ${{ runner.temp }}
 
       - name: Session info
         run: |

--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -237,7 +237,7 @@ runs:
 
       - name: Install quarto if needed
         if: ${{ steps.check-quarto.outputs.install == 'true' }}
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: gaborcsardi/quarto-actions/setup@fix/setup-runner-temp
         with:
           version: ${{ inputs.quarto-version }}
 


### PR DESCRIPTION
If `working-directory` applies to actions at all.