### PR TITLE
Update quarto-dev/quarto-actions/setup to v2.1.6

### DIFF
--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -238,7 +238,7 @@ runs:
 
       - name: Install quarto if needed
         if: ${{ steps.check-quarto.outputs.install == 'true' }}
-        uses: quarto-dev/quarto-actions/setup@577558713f28cb3a0e7a735f80dce913d89b77d2
+        uses: quarto-dev/quarto-actions/setup@87b35bb88b36317fa36b5189e9553b4164a5c5a3
         with:
           version: ${{ inputs.quarto-version }}
 


### PR DESCRIPTION
* quarto-dev/quarto-actions/setup was pinned in https://github.com/r-lib/actions/pull/908 to pull from PR https://github.com/quarto-dev/quarto-actions/pull/111
* PR https://github.com/quarto-dev/quarto-actions/pull/111 was merged and included in [v2.1.5](https://github.com/quarto-dev/quarto-actions/releases/tag/v2.1.5)
* Similar to the user in #901, my GitHub Enterprise is strict about which versions of actions are approved. Only specific commits are approved, and IT currently approved the latest commit [87b35bb](https://github.com/quarto-dev/quarto-actions/commit/87b35bb88b36317fa36b5189e9553b4164a5c5a3) of [v2](https://github.com/quarto-dev/quarto-actions/commits/v2.1.6), which is [v2.1.6](https://github.com/quarto-dev/quarto-actions/commits/v2.1.6)