### PR TITLE
[setup-r]: better document 'r-version' parameter

### DIFF
--- a/setup-r/README.md
+++ b/setup-r/README.md
@@ -26,11 +26,25 @@ This action sets up an R environment for use in actions by:
 
 ## Inputs
 
-- **r-version** (`'release'`) - Version range or exact version of an R
-  version to use. “devel” is the current development version, and “next”
-  is the next version of R, either R-patched, or R-alpha, R-beta, R-rc
-  or R-prerelease. Use “renv” to retrieve R version recorded in
-  renv.lock file.
+- **r-version** (`'release'`) - R version to use. Possible values are:
+
+  - ‘release’: the last released version available for the current
+    platform. ‘latest’ is the same.
+  - ‘devel’: the last daily development snapshot available.
+  - ‘next’: the next version of R, either R-patched, or R-alpha, R-beta,
+    R-rc or R-prerelease depending on the current stage of the R release
+    process.
+  - ‘renv’: retrieve the R version recorded in `renv.lock` file.
+  - exact R version, e.g. ‘4.4.2’.
+  - minor R version, e.g. ‘4.4’. Chooses the last release from this
+    minor version. (Equivalent to using ‘x’ as the patch version,
+    e.g. ‘4.4.x’.)
+  - major R version, e.g. ‘4’. Chooses the last release from this major
+    version. (Equivalent to using ‘x’ as the minor and patch versions,
+    e.g. ‘4.x.x’.)
+  - ‘oldrel’, the previous version of R, not counting patch versions.
+  - ‘oldrel/n’ (or ‘oldrel-n’): the n-th previous version of R, not
+    counting patch versions.
 
 - **rtools-version** (`''`) - Exact version of Rtools to use. Default
   uses latest suitable rtools for the given version of R. Set it to “42”

--- a/setup-r/action.yml
+++ b/setup-r/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: 'Version range or exact version of an R version to use. "devel" is
     the current development version, and "next" is the next version of R, either
     R-patched, or R-alpha, R-beta, R-rc or R-prerelease. Use "renv" to retrieve R
-    version recorded in renv.lock file.'
+    version recorded in renv.lock file. See r-hub rversions/resolve API for more details.'
     default: 'release'
   rtools-version:
     description: |

--- a/setup-r/action.yml
+++ b/setup-r/action.yml
@@ -3,10 +3,22 @@ description: 'Setup a R environment and add it to the PATH'
 author: 'Jim Hester'
 inputs:
   r-version:
-    description: 'Version range or exact version of an R version to use. "devel" is
-    the current development version, and "next" is the next version of R, either
-    R-patched, or R-alpha, R-beta, R-rc or R-prerelease. Use "renv" to retrieve R
-    version recorded in renv.lock file. See r-hub rversions/resolve API for more details.'
+    description: |
+      R version to use. Possible values are:
+        * 'release': the last released version available for the current platform.
+          'latest' is the same.
+        * 'devel': the last daily development snapshot available.
+        * 'next': the next version of R, either R-patched, or R-alpha, R-beta, R-rc
+          or R-prerelease depending on the current stage of the R release process.
+        * 'renv': retrieve the R version recorded in `renv.lock` file.
+        * exact R version, e.g. '4.4.2'.
+        * minor R version, e.g. '4.4'. Chooses the last release from this minor version.
+          (Equivalent to using 'x' as the patch version, e.g. '4.4.x'.)
+        * major R version, e.g. '4'. Chooses the last release from this major version.
+          (Equivalent to using 'x' as the minor and patch versions, e.g. '4.x.x'.)
+        * 'oldrel', the previous version of R, not counting patch versions.
+        * 'oldrel/n' (or 'oldrel-n'): the n-th previous version of R, not counting
+          patch versions.
     default: 'release'
   rtools-version:
     description: |


### PR DESCRIPTION
Related to #935 -- is this helpful? Or guilty of exposing implementation details we'd rather not?

ref:

https://github.com/r-lib/actions/blob/3f55ea1e7439a0db933b2d84686c94fbb4e08602/setup-r/src/installer.ts#L734

(PS didn't compile this to the README yet)