### PR TITLE
speed up `lint-changed-files`

### DIFF
--- a/examples/lint-changed-files.yaml
+++ b/examples/lint-changed-files.yaml
@@ -16,7 +16,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
-
+        with:
+          use-public-rspm: true
+          
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |


### PR DESCRIPTION
Using the posit package manager gives a huge speed-up in this GHA. 
For example, here are two test PRs with the same minimal content, except for adding 
```
with:
   use-public-rspm: true
```

to the `r-lib/actions/setup-r@v2` step of `lint-changed-files.yaml`:

- original: https://github.com/d-morrison/test.lint/actions/runs/11712842490/job/32624409976?pr=1
   - runtime 4m 2s
   - 41 packages installed
- modified: https://github.com/d-morrison/test.lint/actions/runs/11712865780/job/32624476554?pr=2
   - runtime 1m 12s
   - 18 packages installed

This difference becomes much more pronounced in practice; for example:
- original: https://github.com/UCD-SERG/serocalculator/actions/runs/11712411856/job/32623021739 (27m 47s)
- modified: https://github.com/UCD-SERG/serocalculator/actions/runs/11712571048/job/32623552379 (1m 38s)
