### PR TITLE
setup-r action: Document missing 'cran' input

### DIFF
--- a/setup-r/README.Rmd
+++ b/setup-r/README.Rmd
@@ -30,7 +30,15 @@ action <- yaml::read_yaml("action.yml")
 action_df <- tibble::tibble(
   name = names(action$inputs),
   description = purrr::map_chr(action$inputs, "description"),
-  default = purrr::map_chr(action$inputs, ~ if (is.logical(.x$default)) if (isTRUE(.x$default)) "true" else "false" else glue::single_quote(.x$default))
+  default = purrr::map_chr(action$inputs, ~ {
+    if (!"default" %in% names(.x)) {
+      NA_character_
+    } else if (is.logical(.x$default)) {
+      if (isTRUE(.x$default)) "true" else "false"
+    } else {
+      glue::single_quote(.x$default)
+    }
+  })
 )
 cat(glue::glue_data(action_df, "- **{name}** (`{default}`) - {description}"), sep = "\n")
 ```

--- a/setup-r/README.md
+++ b/setup-r/README.md
@@ -78,6 +78,9 @@ This action sets up an R environment for use in actions by:
   you can specify a subdirectory of the repo where some relevant file,
   such as “renv.lock”, should be found.
 
+- **cran** (`NA`) - The CRAN mirror to use. If not specified, the CRAN
+  environment variable is used, or finally the default CRAN mirror.
+
 ## Outputs
 
 - **installed-r-version** - The full R version installed by the action

--- a/setup-r/action.yml
+++ b/setup-r/action.yml
@@ -60,6 +60,9 @@ inputs:
       Using the working-directory keyword, you can specify a subdirectory of the repo where some
       relevant file, such as "renv.lock", should be found.
     default: '.'
+  cran:
+    description: 'The CRAN mirror to use. If not specified, the CRAN environment variable is used, or finally the default CRAN mirror.'
+    required: false
 outputs:
   installed-r-version:
     description: 'The full R version installed'


### PR DESCRIPTION
Defining the `cran` input currently gives a warning when running the setup-r action, but it is actually read at https://github.com/r-lib/actions/blob/v2-branch/setup-r/src/installer.ts#L658