### PR TITLE
feat(setup-r-dependencies): support `dependencies: 'FALSE'`

### DIFF
--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -155,6 +155,7 @@ runs:
             }
           cat("r-version=", r_version, "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
           needs <- sprintf("Config/Needs/%s", strsplit("${{ inputs.needs }}", "[[:space:],]+")[[1]])
+          if (length(needs) == 0L) needs <- NULL
           deps <- strsplit("${{ inputs.packages }}", "[[:space:],]+")[[1]]
           extra_deps <- strsplit("${{ inputs.extra-packages }}", "[[:space:],]+")[[1]]
           dir.create(".github", showWarnings=FALSE)


### PR DESCRIPTION
This change will allow the following, which do not install dependencies and only want to install `extra-packages`.
Something like:

```yml
      - uses: r-lib/actions/setup-r-dependencies@v2
        with:
          dependencies: 'FALSE'
          extra-packages: any::pkgload
```