### PR TITLE
Do not upload coverage results to Codecov when run in a fork

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -326,6 +326,7 @@ jobs:
         shell: Rscript {0}
 
       - uses: codecov/codecov-action@v4
+        if: github.event.repository.fork == false
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}

--- a/examples/test-coverage.yaml
+++ b/examples/test-coverage.yaml
@@ -38,6 +38,7 @@ jobs:
         shell: Rscript {0}
 
       - uses: codecov/codecov-action@v4
+        if: github.event.repository.fork == false
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
When I sync my fork of a repository that has set `CODECOV_TOKEN` to upload coverage results to Codecov (https://github.com/r-lib/actions/issues/834), the step to upload the coverage results to Codecov fails because my fork has not defined `CODECOV_TOKEN`.

This PR updates the Codecov upload step to be skipped when running in a fork. However, it will still perform a token-less upload in a PR submitted from a fork. I learned about the existence of the variable `github.event.repository.fork` from https://github.com/peaceiris/actions-gh-pages/issues/153#issuecomment-598289743

I've tested this update in two repositories I help maintain (https://github.com/Merck/simtrial/pull/307, https://github.com/Merck/gsDesign2/pull/496).