### PR TITLE
quarto-dev/quarto-actions/setup works on arm64 linux

### DIFF
--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -273,10 +273,6 @@ runs:
             if (Sys.which("quarto") != "") {
               cat("Quarto is already installed at", Sys.which("quarto"), "\n")
               o <- "false"
-            } else if (Sys.info()[["machine"]] == "aarch64" && Sys.info()[["sysname"]] == "Linux") {
-              # do not install on aarch64 Linux, until this is merged and published:
-              # https://github.com/quarto-dev/quarto-actions/pull/122
-              o <- "false"
             } else {
               qmd <- dir(recursive = TRUE, pattern = "[.]qmd$")
               if (length(qmd) > 0) {
@@ -295,7 +291,7 @@ runs:
 
       - name: Install quarto if needed
         if: ${{ steps.check-quarto.outputs.install == 'true' }}
-        uses: quarto-dev/quarto-actions/setup@87b35bb88b36317fa36b5189e9553b4164a5c5a3
+        uses: quarto-dev/quarto-actions/setup@9e48da27e184aa238fcb49f5db75469626d43adb
         with:
           version: ${{ inputs.quarto-version }}
 


### PR DESCRIPTION
So setup-r-dependencies can install quarto on
that platform.