### PR TITLE
setup-r-dependencies: put repo status into a group

### DIFF
--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -142,8 +142,11 @@ runs:
 
       - name: Repo status
         run: |
+          # Repo status
+          cat("::group::Repo status\n")
           options(width = 1000)
           pak::repo_status()
+          cat("::endgroup::\n")
         shell: Rscript {0}
 
       - name: Query dependencies


### PR DESCRIPTION
So it is folded by default.