### PR TITLE
doc: `Rtools` no longer installed on GHA runners

### DIFF
--- a/setup-r/action.yml
+++ b/setup-r/action.yml
@@ -24,9 +24,7 @@ inputs:
     description: |
       Exact version of Rtools to use. Default uses latest suitable
       rtools for the given version of R. Set it to "42" for Rtools42.
-      If it is 'none', then Rtools will not be installed. (Note that
-      there is still a pre-installed version of Rtools on the
-      GitHub-hosted GHA runners.)
+      If it is 'none', then Rtools will not be installed.
     default: ''
   Ncpus:
     description: 'Value to set the R option `Ncpus` to.'


### PR DESCRIPTION
There are no longer default rtools installed on Githubs runners.