### PR TITLE
Update actions/checkout to v6, upload-artifact to v7, codecov/codecov-action to v6, and actions/upload-pages-artifact to v5, actions/cache to v5

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,5 @@
 ^check-r-package$
 ^setup-r-dependencies$
 ^setup-renv$
+^setup-manifest$
+^_pkgdown\.yml$

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -35,16 +35,14 @@ jobs:
           - {os: ubuntu-latest,  r: 'oldrel-2'}
           - {os: ubuntu-latest,  r: 'oldrel-3'}
           - {os: ubuntu-latest,  r: 'oldrel-4'}
-
           - {os: ubuntu-22.04-arm, r: 'release' }
-
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - uses: ./setup-pandoc
 

--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -16,7 +16,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - uses: ./setup-r
         with:

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -30,7 +30,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - uses: ./setup-pandoc
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - uses: ./setup-r
         with:

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -16,7 +16,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
+      - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7 # v6.0.0
         with:
           issue-inactive-days: '14'
           issue-comment: >

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - uses: ./setup-pandoc
 

--- a/.github/workflows/r-devel-test.yaml
+++ b/.github/workflows/r-devel-test.yaml
@@ -38,7 +38,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - uses: r-hub/actions/debug-shell@v1
 

--- a/.github/workflows/rtools.yaml
+++ b/.github/workflows/rtools.yaml
@@ -27,7 +27,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - uses: ./setup-pandoc
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -69,6 +69,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@1b1aada464948af03b950897e5eb522f92603cc2 # v3.24.9
+        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -60,7 +60,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/setup-pandoc-test.yaml
+++ b/.github/workflows/setup-pandoc-test.yaml
@@ -27,6 +27,8 @@ jobs:
         config:
           - { os: macos-14         }
           - { os: macos-15-intel   }
+          - { os: macos-latest     }
+          - { os: macos-26         }  
           - { os: windows-latest   }
           - { os: ubuntu-latest    }
           - { os: ubuntu-22.04-arm }

--- a/.github/workflows/setup-pandoc-test.yaml
+++ b/.github/workflows/setup-pandoc-test.yaml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         config:
           - { os: macos-14         }
-          - { os: macos-13         }
+          - { os: macos-15-intel   }
           - { os: windows-latest   }
           - { os: ubuntu-latest    }
           - { os: ubuntu-22.04-arm }

--- a/.github/workflows/setup-pandoc-test.yaml
+++ b/.github/workflows/setup-pandoc-test.yaml
@@ -34,7 +34,7 @@ jobs:
           - { os: ubuntu-22.04-arm }
 
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - uses: ./setup-pandoc
         with:

--- a/.github/workflows/setup-r-test.yaml
+++ b/.github/workflows/setup-r-test.yaml
@@ -39,7 +39,7 @@ jobs:
     name: ${{ github.event.inputs.inpos }} (${{ matrix.r }})
 
     steps:
-    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
     - uses: ./setup-r
       id: setup-r

--- a/.github/workflows/setup-tinytex.yaml
+++ b/.github/workflows/setup-tinytex.yaml
@@ -23,7 +23,7 @@ jobs:
           - { os: ubuntu-latest  }
 
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - uses: ./setup-tinytex
         env:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -16,7 +16,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - uses: ./setup-r
         with:
@@ -34,15 +34,16 @@ jobs:
             clean = FALSE,
             install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
+          print(cov)
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@f1b7348826d750ac29741abc9d1623d8da5dcd4f
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
-          file: ./cobertura.xml
-          plugin: noop
+          files: ./cobertura.xml
+          plugins: noop
           disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -55,7 +56,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all : $(WORKFLOWS)
 
 $(WORKFLOWS) : .github/workflows/%.yaml: examples/%.yaml Makefile
 	perl -pe 's{r-lib/actions/([\w-]+)\@v2}{./$$1}g' $< | \
-	perl -pe 's{actions/checkout\@v4}{actions/checkout\@0ad4b8fadaa221de15dcec353f45205ec38ea70b}g' | \
+	perl -pe 's{actions/checkout\@v6}{actions/checkout\@de0fac2e4500dabe0009e67214ff5f5447ce83dd}g' | \
 	perl -pe 's{actions/upload-artifact\@v4}{actions/upload-artifact\@65462800fd760344b1a7b4382951275a0abb4808}g' | \
 	perl -pe 's{codecov/codecov-action\@v4}{codecov/codecov-action\@f1b7348826d750ac29741abc9d1623d8da5dcd4f}g' | \
 	perl -pe 's{JamesIves/github-pages-deploy-action\@v4[.]5[.]0}{JamesIves/github-pages-deploy-action\@65b5dfd4f5bcd3a7403bbc2959c144256167464e}g' | \

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,14 @@ all : $(WORKFLOWS)
 $(WORKFLOWS) : .github/workflows/%.yaml: examples/%.yaml Makefile
 	perl -pe 's{r-lib/actions/([\w-]+)\@v2}{./$$1}g' $< | \
 	perl -pe 's{actions/checkout\@v6}{actions/checkout\@de0fac2e4500dabe0009e67214ff5f5447ce83dd}g' | \
-	perl -pe 's{actions/upload-artifact\@v4}{actions/upload-artifact\@65462800fd760344b1a7b4382951275a0abb4808}g' | \
-	perl -pe 's{codecov/codecov-action\@v4}{codecov/codecov-action\@f1b7348826d750ac29741abc9d1623d8da5dcd4f}g' | \
+	perl -pe 's{actions/upload-artifact\@v7}{actions/upload-artifact\@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a}g' | \
+	perl -pe 's{codecov/codecov-action\@v6}{codecov/codecov-action\@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2}g' | \
 	perl -pe 's{JamesIves/github-pages-deploy-action\@v4[.]5[.]0}{JamesIves/github-pages-deploy-action\@65b5dfd4f5bcd3a7403bbc2959c144256167464e}g' | \
-	perl -pe 's{main, master}{main, master, v2-branch}g' > $@
+	perl -pe 's{main, master}{main, master, v2-branch}g' | \
+	if [ "$*" = "check-full" ]; then \
+	  perl -pe 's{(- \{os: ubuntu-latest,  r: \x27oldrel-4\x27\})}{$$1\n          - {os: ubuntu-22.04-arm, r: \x27release\x27 }}g' | \
+	  perl -pe 's{(- uses: \./setup-r-dependencies)}{- uses: gaborcsardi/quarto-actions/setup\@fix/linux-arm64\n\n      $$1}g'; \
+	else cat; fi > $@
 
 .PHONY: clean
 clean:

--- a/R/foo.R
+++ b/R/foo.R
@@ -7,3 +7,7 @@ add_one <- function(x) {
 times2 <- function(x) {
   .Call(test_fun, as.integer(x)[1])
 }
+
+plus <- function(x, y) {
+  x + y
+}

--- a/check-r-package/README.md
+++ b/check-r-package/README.md
@@ -37,7 +37,7 @@ Inputs available:
 Basic:
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 - uses: r-lib/actions/setup-r@v2
 - uses: r-lib/actions/setup-r-dependencies@v2
   with:
@@ -49,7 +49,7 @@ steps:
 With specified inputs:
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 - uses: r-lib/actions/setup-r@v2
 - uses: r-lib/actions/setup-r-dependencies@v2
   with:

--- a/check-r-package/action.yaml
+++ b/check-r-package/action.yaml
@@ -62,14 +62,14 @@ runs:
 
     - name: Upload check results
       if: ${{ (failure() && inputs.upload-results != 'never') || (inputs.upload-results != 'false' && inputs.upload-results != 'never') }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.artifact-name || format('{0}-{1}-r{2}-{3}-results', runner.os, runner.arch, matrix.config.r, matrix.config.id || strategy.job-index ) }}
         path: ${{ steps.rcmdcheck.outputs.check-dir-path }}
 
     - name: Upload snapshots
       if: ${{ (failure() && inputs.upload-snapshots == 'always') || inputs.upload-snapshots != 'false' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.snapshot-artifact-name || format('{0}-{1}-r{2}-{3}-testthat-snapshots', runner.os, runner.arch, matrix.config.r, matrix.config.id || strategy.job-index ) }}
         path: ${{ steps.rcmdcheck.outputs.check-dir-path }}/**/tests*/testthat/_snaps

--- a/examples/README.md
+++ b/examples/README.md
@@ -342,7 +342,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/examples/README.md
+++ b/examples/README.md
@@ -92,7 +92,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -157,7 +157,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -240,7 +240,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -303,7 +303,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -373,7 +373,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -428,7 +428,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/pr-fetch@v2
         with:
@@ -467,7 +467,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/pr-fetch@v2
         with:
@@ -523,7 +523,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -593,7 +593,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -647,7 +647,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -703,7 +703,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -811,7 +811,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -871,7 +871,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -964,7 +964,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -1021,7 +1021,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -1106,7 +1106,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -1184,7 +1184,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/examples/README.md
+++ b/examples/README.md
@@ -736,7 +736,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache styler
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.styler-location.outputs.location }}
           key: ${{ runner.os }}-styler-${{ github.sha }}
@@ -823,7 +823,7 @@ jobs:
       - uses: r-lib/actions/setup-renv@v2
 
       - name: Cache bookdown results
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: _bookdown_files
           key: bookdown-${{ hashFiles('**/*Rmd') }}
@@ -883,7 +883,7 @@ jobs:
       - uses: r-lib/actions/setup-renv@v2
 
       - name: Cache bookdown results
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: _bookdown_files
           key: bookdown-${{ hashFiles('**/*Rmd') }}

--- a/examples/README.md
+++ b/examples/README.md
@@ -324,7 +324,7 @@ jobs:
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}

--- a/examples/README.md
+++ b/examples/README.md
@@ -895,7 +895,7 @@ jobs:
 
       - name: Upload website artifact
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "_book"
 
@@ -1042,7 +1042,7 @@ jobs:
 
       - name: Upload website artifact
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "public"
 

--- a/examples/blogdown-gh-pages.yaml
+++ b/examples/blogdown-gh-pages.yaml
@@ -19,7 +19,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/examples/blogdown-gh-pages.yaml
+++ b/examples/blogdown-gh-pages.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload website artifact
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "public"
 

--- a/examples/blogdown.yaml
+++ b/examples/blogdown.yaml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/examples/bookdown-gh-pages.yaml
+++ b/examples/bookdown-gh-pages.yaml
@@ -19,7 +19,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/examples/bookdown-gh-pages.yaml
+++ b/examples/bookdown-gh-pages.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: r-lib/actions/setup-renv@v2
 
       - name: Cache bookdown results
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: _bookdown_files
           key: bookdown-${{ hashFiles('**/*Rmd') }}

--- a/examples/bookdown-gh-pages.yaml
+++ b/examples/bookdown-gh-pages.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload website artifact
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "_book"
 

--- a/examples/bookdown.yaml
+++ b/examples/bookdown.yaml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/examples/bookdown.yaml
+++ b/examples/bookdown.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: r-lib/actions/setup-renv@v2
 
       - name: Cache bookdown results
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: _bookdown_files
           key: bookdown-${{ hashFiles('**/*Rmd') }}

--- a/examples/check-full.yaml
+++ b/examples/check-full.yaml
@@ -41,7 +41,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/examples/check-no-suggests.yaml
+++ b/examples/check-no-suggests.yaml
@@ -32,7 +32,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/examples/check-release.yaml
+++ b/examples/check-release.yaml
@@ -16,7 +16,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/examples/check-standard.yaml
+++ b/examples/check-standard.yaml
@@ -30,7 +30,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/examples/document.yaml
+++ b/examples/document.yaml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/examples/html-5-check.yaml
+++ b/examples/html-5-check.yaml
@@ -16,7 +16,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/examples/lint-changed-files.yaml
+++ b/examples/lint-changed-files.yaml
@@ -13,7 +13,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
 

--- a/examples/lint-project.yaml
+++ b/examples/lint-project.yaml
@@ -15,7 +15,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/examples/lint.yaml
+++ b/examples/lint.yaml
@@ -15,7 +15,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/examples/pkgdown.yaml
+++ b/examples/pkgdown.yaml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/examples/pr-commands.yaml
+++ b/examples/pr-commands.yaml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/pr-fetch@v2
         with:
@@ -57,7 +57,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/pr-fetch@v2
         with:

--- a/examples/render-rmarkdown.yaml
+++ b/examples/render-rmarkdown.yaml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/examples/shiny-deploy.yaml
+++ b/examples/shiny-deploy.yaml
@@ -14,7 +14,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/examples/style.yaml
+++ b/examples/style.yaml
@@ -49,7 +49,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache styler
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.styler-location.outputs.location }}
           key: ${{ runner.os }}-styler-${{ github.sha }}

--- a/examples/style.yaml
+++ b/examples/style.yaml
@@ -17,7 +17,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/examples/test-coverage.yaml
+++ b/examples/test-coverage.yaml
@@ -16,7 +16,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/examples/test-coverage.yaml
+++ b/examples/test-coverage.yaml
@@ -38,7 +38,7 @@ jobs:
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}

--- a/examples/test-coverage.yaml
+++ b/examples/test-coverage.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/pr-fetch/README.md
+++ b/pr-fetch/README.md
@@ -27,7 +27,7 @@ jobs:
     name: foo
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: r-lib/actions/pr-fetch@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/pr-push/README.md
+++ b/pr-push/README.md
@@ -28,7 +28,7 @@ jobs:
     name: foo
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: r-lib/actions/pr-fetch@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/setup-manifest/README.md
+++ b/setup-manifest/README.md
@@ -20,7 +20,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: r-lib/actions/setup-manifest@feature/setup-manifest
 ```
 

--- a/setup-pandoc/README.md
+++ b/setup-pandoc/README.md
@@ -32,7 +32,7 @@ not currently have nightly builds for arm64 machines, so using
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 - uses: r-lib/actions/setup-pandoc@v2
   with:
     pandoc-version: '3.1.11' # The pandoc version to download (if necessary) and use.

--- a/setup-r-dependencies/README.md
+++ b/setup-r-dependencies/README.md
@@ -65,7 +65,7 @@ Inputs available
 Basic:
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 - uses: r-lib/actions/setup-r@v2
 - uses: r-lib/actions/setup-r-dependencies@v2
   with:
@@ -155,7 +155,7 @@ write this in the butcher workflow file:
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 - uses: r-lib/actions/setup-r@v2
 - uses: r-lib/actions/setup-r-dependencies@v2
   with:
@@ -200,7 +200,7 @@ package as `local::.` to pak:
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 - uses: r-lib/actions/setup-r@v2
 - uses: r-lib/actions/setup-r-dependencies@v2
   with:

--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -207,7 +207,7 @@ runs:
       - name: R package cache restore
         id: cache-packages-restore
         if: inputs.cache == 'always'
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             ${{ env.R_LIBS_USER }}/*

--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -326,7 +326,7 @@ runs:
 
       - name: R package cache save
         if: ${{ always() && steps.cache-packages-restore.outputs.cache-hit != 'true' && inputs.cache == 'always' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             ${{ env.R_LIBS_USER }}/*

--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -194,7 +194,7 @@ runs:
 
       - name: R package cache
         if: inputs.cache == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ${{ env.R_LIBS_USER }}/*

--- a/setup-r/README.Rmd
+++ b/setup-r/README.Rmd
@@ -52,7 +52,7 @@ cat(glue::glue_data(action_df, "- **{name}** (`{default}`) - {description}"), se
 Basic:
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 - uses: r-lib/actions/setup-r@v2
   with:
     r-version: '3.5.3' # The R version to download (if necessary) and use.
@@ -70,7 +70,7 @@ jobs:
         R: [ '3.5.3', '3.6.1' ]
     name: R ${{ matrix.R }} sample
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:

--- a/setup-r/README.md
+++ b/setup-r/README.md
@@ -105,7 +105,7 @@ Basic:
 
 ``` yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 - uses: r-lib/actions/setup-r@v2
   with:
     r-version: '3.5.3' # The R version to download (if necessary) and use.
@@ -124,7 +124,7 @@ jobs:
         R: [ '3.5.3', '3.6.1' ]
     name: R ${{ matrix.R }} sample
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:

--- a/setup-renv/README.md
+++ b/setup-renv/README.md
@@ -28,7 +28,7 @@ Example:
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 - uses: r-lib/actions/setup-r@v2
 - uses: r-lib/actions/setup-renv@v2
   with:

--- a/setup-renv/action.yaml
+++ b/setup-renv/action.yaml
@@ -76,7 +76,7 @@ runs:
 
       - name: Save Renv package cache
         if: ${{ always() && steps.cache-packages-restore.outputs.cache-hit != 'true' && (inputs.bypass-cache == 'always' || inputs.bypass-cache == 'never') }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             ${{ env.RENV_PATHS_ROOT }}

--- a/setup-renv/action.yaml
+++ b/setup-renv/action.yaml
@@ -43,7 +43,7 @@ runs:
 
       - name: Restore Renv package cache
         if: ${{ inputs.bypass-cache == 'false' }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ${{ env.RENV_PATHS_ROOT }}

--- a/setup-renv/action.yaml
+++ b/setup-renv/action.yaml
@@ -54,7 +54,7 @@ runs:
       - name: Restore Renv package cache
         id: cache-packages-restore
         if: ${{ inputs.bypass-cache == 'always' || inputs.bypass-cache == 'never' }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             ${{ env.RENV_PATHS_ROOT }}

--- a/setup-tinytex/README.md
+++ b/setup-tinytex/README.md
@@ -13,7 +13,7 @@ See [action.yml](action.yml)
 Basic:
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 - uses: r-lib/actions/setup-tinytex@v2
 - run: tlmgr --version
 ```
@@ -29,7 +29,7 @@ For example this is the case if your R package builds its PDF reference manual a
 To install CTAN packages manually, you can call `tlmgr` from your workflow. We suggest you also run `tlmgr update --self` before installing, otherwise the installation may fail. Here is a complete example:
 ```yaml
 steps:
-  - uses: actions/checkout@v4
+  - uses: actions/checkout@v6
   - uses: r-lib/actions/setup-tinytex@v2
   - run: tlmgr --version
 

--- a/tests/testthat/test.R
+++ b/tests/testthat/test.R
@@ -13,3 +13,7 @@ test_that("times2 works", {
   expect_equal(times2(10), 20L)
   expect_equal(times2(0), 0L)
 })
+
+test_that("plus works", {
+  expect_equal(plus(1, 2), 3)
+})

--- a/tests/testthat/test.R
+++ b/tests/testthat/test.R
@@ -3,3 +3,13 @@ test_that("snap", {
   local_edition(3)
   expect_snapshot(mtcars)
 })
+
+test_that("add_one works", {
+  expect_equal(add_one(1), 2)
+  expect_equal(add_one(0), 1)
+})
+
+test_that("times2 works", {
+  expect_equal(times2(10), 20L)
+  expect_equal(times2(0), 0L)
+})


### PR DESCRIPTION
This 

* updates `actions/checkout` to `v6` in the examples and READMEs
* updates `actions/checkout` to its v6.0.2 commit in the Makefile and workflows
* updates `actions/upload-artifact` to v7
* updates `actions/upload-artifact` to its v7.0.1 commit in the Makefile and workflows
* updates `codecov/codecov-action` to v6
* updates `codecov/codecov-action` to its v6.0.0 commit in the Makefile and workflows, and then makes the minor update to the _.github/workflows/test-coverage.yaml_ workflow
* updates `actions/upload-pages-artifact` to v5
* updates `actions/cache` to v5 in the examples and READMEs and bumps `actions/cache/save` and `actions/cache/restore` to v5
* refreshes the list of macos runners in .github/workflows/setup-pandoc-test.yaml
* adds two missing files to .Rbuildignore
* updates actions in .github/workflows/scorecard.yml
* updates `dessant/lock-threads` to v6.0.0

Closes #1042 