### PR TITLE
Bump upload-pages-artifact to v4 sliding tag

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -895,7 +895,7 @@ jobs:
 
       - name: Upload website artifact
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: "_book"
 
@@ -1042,7 +1042,7 @@ jobs:
 
       - name: Upload website artifact
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: "public"
 

--- a/examples/blogdown-gh-pages.yaml
+++ b/examples/blogdown-gh-pages.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload website artifact
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: "public"
 

--- a/examples/bookdown-gh-pages.yaml
+++ b/examples/bookdown-gh-pages.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload website artifact
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: "_book"
 


### PR DESCRIPTION
I noticed that `actions/upload-pages-artifact` has bumped its version to v4 <https://github.com/actions/upload-pages-artifact>