### PR TITLE
Update upload-artifact to v5

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all : $(WORKFLOWS)
 $(WORKFLOWS) : .github/workflows/%.yaml: examples/%.yaml Makefile
 	perl -pe 's{r-lib/actions/([\w-]+)\@v2}{./$$1}g' $< | \
 	perl -pe 's{actions/checkout\@v4}{actions/checkout\@0ad4b8fadaa221de15dcec353f45205ec38ea70b}g' | \
-	perl -pe 's{actions/upload-artifact\@v4}{actions/upload-artifact\@65462800fd760344b1a7b4382951275a0abb4808}g' | \
+	perl -pe 's{actions/upload-artifact\@v5}{actions/upload-artifact\@330a01c490aca151604b8cf639adc76d48f6c5d4}g' | \
 	perl -pe 's{codecov/codecov-action\@v4}{codecov/codecov-action\@f1b7348826d750ac29741abc9d1623d8da5dcd4f}g' | \
 	perl -pe 's{JamesIves/github-pages-deploy-action\@v4[.]5[.]0}{JamesIves/github-pages-deploy-action\@65b5dfd4f5bcd3a7403bbc2959c144256167464e}g' | \
 	perl -pe 's{main, master}{main, master, v2-branch}g' > $@

--- a/check-r-package/action.yaml
+++ b/check-r-package/action.yaml
@@ -62,14 +62,14 @@ runs:
 
     - name: Upload check results
       if: ${{ (failure() && inputs.upload-results != 'never') || (inputs.upload-results != 'false' && inputs.upload-results != 'never') }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: ${{ inputs.artifact-name || format('{0}-{1}-r{2}-{3}-results', runner.os, runner.arch, matrix.config.r, matrix.config.id || strategy.job-index ) }}
         path: ${{ steps.rcmdcheck.outputs.check-dir-path }}
 
     - name: Upload snapshots
       if: ${{ (failure() && inputs.upload-snapshots == 'always') || inputs.upload-snapshots != 'false' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: ${{ inputs.snapshot-artifact-name || format('{0}-{1}-r{2}-{3}-testthat-snapshots', runner.os, runner.arch, matrix.config.r, matrix.config.id || strategy.job-index ) }}
         path: ${{ steps.rcmdcheck.outputs.check-dir-path }}/**/tests*/testthat/_snaps

--- a/examples/README.md
+++ b/examples/README.md
@@ -342,7 +342,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/examples/test-coverage.yaml
+++ b/examples/test-coverage.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package


### PR DESCRIPTION
I noticed that actions/upload-artifact now has a v5 sliding tag <https://github.com/actions/upload-artifact>