### PR TITLE
Update all actions from node20 to node24

### DIFF
--- a/pr-fetch/action.yml
+++ b/pr-fetch/action.yml
@@ -5,5 +5,5 @@ inputs:
   repo-token:
     description: 'Token for the repo. Can be passed in using {{ secrets.GITHUB_TOKEN }}'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/pr-push/action.yml
+++ b/pr-push/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: 'String of additional command line args to `git push`'
     default: '-q'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/setup-pandoc/action.yml
+++ b/setup-pandoc/action.yml
@@ -22,5 +22,5 @@ inputs:
       GitHub token to use to download nightly builds of pandoc.
       It is not needed for other pandoc versions.
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/setup-r/action.yml
+++ b/setup-r/action.yml
@@ -79,5 +79,5 @@ outputs:
   installed-r-version:
     description: 'The full R version installed'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/setup-tinytex/action.yml
+++ b/setup-tinytex/action.yml
@@ -2,5 +2,5 @@ name: 'Setup TinyTeX'
 description: 'Setup TinyTeX and add it to your PATH'
 author: 'Jim Hester'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
Fixes #1044

## Summary
- Updates `using: 'node20'` to `using: 'node24'` in all 5 JavaScript-based actions: `setup-r`, `setup-pandoc`, `setup-tinytex`, `pr-fetch`, `pr-push`
- GitHub will force Node.js 24 runtime starting June 2, 2026