### PR TITLE
Pin SHA of dependent actions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@
   Windows. macOS binaries require further opt-in with
   `use-public-rspm: always`.
 
+* It is now possible to require actions to be pinned to a full-length
+  commit SHA in repositories using `r-lib/actions` (#1070).
+
 * `[setup-pandoc][setup-r-dependencies]` now default to Pandoc
   version 3.8.3.
 

--- a/check-r-package/action.yaml
+++ b/check-r-package/action.yaml
@@ -62,14 +62,14 @@ runs:
 
     - name: Upload check results
       if: ${{ (failure() && inputs.upload-results != 'never') || (inputs.upload-results != 'false' && inputs.upload-results != 'never') }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: ${{ inputs.artifact-name || format('{0}-{1}-r{2}-{3}-results', runner.os, runner.arch, matrix.config.r, matrix.config.id || strategy.job-index ) }}
         path: ${{ steps.rcmdcheck.outputs.check-dir-path }}
 
     - name: Upload snapshots
       if: ${{ (failure() && inputs.upload-snapshots == 'always') || inputs.upload-snapshots != 'false' }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: ${{ inputs.snapshot-artifact-name || format('{0}-{1}-r{2}-{3}-testthat-snapshots', runner.os, runner.arch, matrix.config.r, matrix.config.id || strategy.job-index ) }}
         path: ${{ steps.rcmdcheck.outputs.check-dir-path }}/**/tests*/testthat/_snaps

--- a/setup-manifest/action.yaml
+++ b/setup-manifest/action.yaml
@@ -14,10 +14,10 @@ runs:
       shell: bash
 
     - name: Install R
-      uses: r-lib/actions/setup-r@v2
+      uses: r-lib/actions/setup-r@9f58233a78a2a9fd874714be10f8bba627233339
       with:
         r-version: renv
         use-public-rspm: true
 
     - name: Install R packages via renv
-      uses: r-lib/actions/setup-renv@v2
+      uses: r-lib/actions/setup-renv@9f58233a78a2a9fd874714be10f8bba627233339

--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -194,7 +194,7 @@ runs:
 
       - name: R package cache
         if: inputs.cache == 'true'
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             ${{ env.R_LIBS_USER }}/*
@@ -207,7 +207,7 @@ runs:
       - name: R package cache restore
         id: cache-packages-restore
         if: inputs.cache == 'always'
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             ${{ env.R_LIBS_USER }}/*
@@ -262,7 +262,7 @@ runs:
 
       - name: Install pandoc if needed
         if: ${{ steps.check-pandoc.outputs.install == 'true' }}
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@9f58233a78a2a9fd874714be10f8bba627233339
         with:
           pandoc-version: ${{ inputs.pandoc-version }}
 
@@ -326,7 +326,7 @@ runs:
 
       - name: R package cache save
         if: ${{ always() && steps.cache-packages-restore.outputs.cache-hit != 'true' && inputs.cache == 'always' }}
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             ${{ env.R_LIBS_USER }}/*

--- a/setup-renv/action.yaml
+++ b/setup-renv/action.yaml
@@ -43,7 +43,7 @@ runs:
 
       - name: Restore Renv package cache
         if: ${{ inputs.bypass-cache == 'false' }}
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             ${{ env.RENV_PATHS_ROOT }}
@@ -54,7 +54,7 @@ runs:
       - name: Restore Renv package cache
         id: cache-packages-restore
         if: ${{ inputs.bypass-cache == 'always' || inputs.bypass-cache == 'never' }}
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             ${{ env.RENV_PATHS_ROOT }}
@@ -76,7 +76,7 @@ runs:
 
       - name: Save Renv package cache
         if: ${{ always() && steps.cache-packages-restore.outputs.cache-hit != 'true' && (inputs.bypass-cache == 'always' || inputs.bypass-cache == 'never') }}
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             ${{ env.RENV_PATHS_ROOT }}


### PR DESCRIPTION
This is somewhat cumbersome for self-dependencies:
```
setup-manifest -> setup-r, setup-renv
setup-r-dependencies -> setup-pandoc
```
because there is no way to match the SHA of the dependency to the SHA of the action depending on it.

So we need to depend on the latest SHA on v2-branch (and not a SHA on a branch that might be removed from a repo!).

In the future we'll need to update these SHA's whenever the dependents change, in a separate PR (!), so that we can refer to a stable commit that will stay on v2-branch.

Closes #1070.