### PR TITLE
Update quarto-dev/quarto-actions/setup to v2.2.0

### DIFF
--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -294,7 +294,7 @@ runs:
 
       - name: Install quarto if needed
         if: ${{ steps.check-quarto.outputs.install == 'true' }}
-        uses: quarto-dev/quarto-actions/setup@9e48da27e184aa238fcb49f5db75469626d43adb
+        uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b
         with:
           version: ${{ inputs.quarto-version }}
 


### PR DESCRIPTION
quarto-dev/quarto-actions [v2.2.0](https://github.com/quarto-dev/quarto-actions/releases/tag/v2.2.0) was released in November 2025

xref: https://github.com/quarto-dev/quarto-actions/commit/8a96df13519ee81fd526f2dfca5962811136661b, https://github.com/r-lib/actions/pull/923