### PR TITLE
[PATCH] setup-r-dependencies: fix pak install on runners with sudo-rs

### DIFF
--- a/setup-r-dependencies/action.yaml
+++ b/setup-r-dependencies/action.yaml
@@ -133,7 +133,7 @@ runs:
         run: |
           # Install pak
           echo "::group::Install pak"
-          if which sudo >/dev/null; then SUDO="sudo -E --preserve-env=PATH env"; else SUDO=""; fi
+          if which sudo >/dev/null; then SUDO="sudo --preserve-env=PATH,R_LIB_FOR_PAK,R_LIBS,R_LIBS_SITE,R_LIBS_USER,RSPM,RENV_CONFIG_REPOS_OVERRIDE,PKGCACHE_HTTP_VERSION,NOT_CRAN,TZ,HOME env"; else SUDO=""; fi
           $SUDO R -q -e 'dir.create(Sys.getenv("R_LIB_FOR_PAK"), recursive = TRUE, showWarnings = FALSE)'
           $SUDO R -q -e 'if ("${{ inputs.pak-version }}" == "repo") { install.packages("pak", lib = Sys.getenv("R_LIB_FOR_PAK")) } else { install.packages("pak", lib = Sys.getenv("R_LIB_FOR_PAK"), repos = sprintf("https://r-lib.github.io/p/pak/%s/%s/%s/%s", "${{ inputs.pak-version }}", .Platform$pkgType, R.Version()$os, R.Version()$arch)) }'
           echo "::endgroup::"


### PR DESCRIPTION
 (Ubuntu 25.10+/26.04)

sudo-rs, the default sudo on Ubuntu 25.10+ (and thus ubuntu-26.04 GitHub-hosted runners), does not support bare -E:

    sudo: preserving the entire environment is not supported, '-E' is ignored

With the environment dropped, R_LIB_FOR_PAK is empty inside the sudo'd R process, so the pak installation fails.

Replace 'sudo -E' with an explicit --preserve-env list of the variables the step actually needs (PATH, R_LIB_FOR_PAK, R library paths, repo settings, HOME for the Rprofile written by setup-r). The list form of --preserve-env is supported by both classic sudo (>= 1.8.21) and sudo-rs.

Fixes #1094