### PR TITLE
fix: Remove stray `::group::`

### DIFF
--- a/setup-pandoc/src/setup-pandoc.ts
+++ b/setup-pandoc/src/setup-pandoc.ts
@@ -275,7 +275,6 @@ async function installPandocLinux(version: string): Promise<void> {
 
   let downloadPath: string;
   try {
-    console.log("::group::Download pandoc");
     downloadPath = await tc.downloadTool(downloadUrl);
   } catch (error) {
     throw new Error(`Failed to download Pandoc ${version}: ${error}`);


### PR DESCRIPTION
Garbles log display on Linux.

<img width="373" height="66" alt="image" src="https://github.com/user-attachments/assets/0c8a1774-9b05-4d3a-b9d0-b21521049e0b" />

A "setup-r" step is defined after "setup-pandoc" in my workflows, not shown here.

Example run (identical across my packages): https://github.com/igraph/rigraph/actions/runs/31236188424/job/93050991268#step:5:1740 .

This is the only `::group::` entry in the whole file.

Groups blog post: https://octocat.dev/posts/Groups-and-formatting-in-GitHub-Actions .